### PR TITLE
feat: [Issue #3] Templates e Entity Definitions para Product Management

### DIFF
--- a/entities/person.md
+++ b/entities/person.md
@@ -53,6 +53,47 @@ Persons are connected to teams and actors via wikilinks. The vault tracks people
 | `slack` | string | Slack handle (e.g., `@alice.smith`) |
 | `jira` | string | Jira username |
 
+## Management fields (frontmatter — optional)
+
+These fields activate management sections in the person note. Only populate when the person is managed (direct report, indirect report, etc.) in a product-management vault.
+
+| Field | Type | Description |
+|---|---|---|
+| `management_role` | string | `direct-report`, `indirect-report`, `peer`, `leader`, `external` — leave empty for non-managed persons |
+| `manager` | wikilink | `"[[manager-slug]]"` — the person's direct manager |
+
+### Competency fields (Reforge Product Competency Model)
+
+Only populate when `management_role` is set. Scale 0-5. Each competency has a leader assessment and self-assessment (`_self` suffix).
+
+| Field | Field (self) | Dimension |
+|---|---|---|
+| `product_sense` | `product_sense_self` | Product Strategy |
+| `analytical` | `analytical_self` | Product Strategy |
+| `execution` | `execution_self` | Product Strategy |
+| `strategic_thinking` | `strategic_thinking_self` | Product Strategy |
+| `fluency` | `fluency_self` | Product Execution |
+| `discovery` | `discovery_self` | Product Execution |
+| `growth` | `growth_self` | Product Execution |
+| `go_to_market` | `go_to_market_self` | Product Execution |
+| `quality` | `quality_self` | Technical |
+| `delivery` | `delivery_self` | Technical |
+| `user_insight` | `user_insight_self` | Research |
+| `data_intuition` | `data_intuition_self` | Research |
+
+## Management sections (body — conditional)
+
+When `management_role` is set, the person note includes additional sections after "Active Topics":
+
+| Section | Purpose | Write rule |
+|---|---|---|
+| **Próximo 1:1** | Checklist of items for the next 1:1 meeting | Insert new items BEFORE `%%vazio%%` placeholder |
+| **Temas em Acompanhamento** | Recurring themes that need follow-up | Append-only |
+| **Desenvolvimento / PDI** | Personal development plan | Append-only |
+| **Log** | Chronological observations (newest on top, `### YYYY-MM-DD` headers) | Insert new entries at the TOP of the section |
+
+**Important:** The `%%vazio%%` placeholder in "Próximo 1:1" must never be removed — it marks the insertion point for new items. `/bedrock:compress` must preserve it.
+
 ## Filename convention
 
 A person's filename is derived from the **corporate email prefix**, normalized:

--- a/entities/team.md
+++ b/entities/team.md
@@ -57,6 +57,17 @@ Teams have a domain scope (e.g., "card transaction lifecycle"), listed members, 
 
 A team is complete when: it has a formal name, a defined scope, at least 1 listed member, and at least 1 actor under ownership. If only the squad name is mentioned without members or actors, the content should go to `fleeting/` until it is consolidated.
 
+## Management sections (body — optional)
+
+For product-management vaults, team notes include additional sections for tracking strategic themes and decisions:
+
+| Section | Purpose | Write rule |
+|---|---|---|
+| **Temas Estratégicos** | Active strategic themes being tracked by the team | Append-only. Format: `- **Theme name:** description *(YYYY-MM-DD)*` |
+| **Decisões Importantes** | Table of key decisions with date and context | Append new rows. Format: `\| YYYY-MM-DD \| Decision \| Context \|` |
+
+These sections are optional and do not affect team notes in non-management vaults.
+
 ## Examples
 
 ### This IS a team

--- a/templates/discussions/_template.md
+++ b/templates/discussions/_template.md
@@ -5,7 +5,7 @@ aliases: []  # ["Short Title"] — min 1 alias if title is long
 date: YYYY-MM-DD
 summary: ""
 conclusions: []
-action_items: []
+action_items: []  # structured: [{description: "", owner: "[[person-slug]]", status: "todo|done", deadline: "YYYY-MM-DD", routed_to: "[[person-slug]]"}]
 related_topics: ["[[YYYY-MM-type-slug]]"]
 related_actors: ["[[repo-name]]"]
 related_people: ["[[first-last]]"]

--- a/templates/people/_template.md
+++ b/templates/people/_template.md
@@ -9,6 +9,36 @@ email: ""  # full corporate email (e.g.: alice.smith@company.com)
 github: ""  # optional — GitHub login, when applicable
 slack: ""  # optional — Slack handle (e.g.: @alice.smith)
 jira: ""
+# --- Management fields (optional — only when management_role is set) ---
+management_role: ""  # direct-report | indirect-report | peer | leader | external — leave empty for non-managed persons
+manager: ""  # "[[manager-slug]]" — wikilink to this person's manager
+# --- Competencies: Reforge Product Competency Model (optional, scale 0-5) ---
+# Only populate when management_role is set. Leader assessment + self-assessment.
+product_sense: 0
+product_sense_self: 0
+analytical: 0
+analytical_self: 0
+execution: 0
+execution_self: 0
+strategic_thinking: 0
+strategic_thinking_self: 0
+fluency: 0
+fluency_self: 0
+discovery: 0
+discovery_self: 0
+growth: 0
+growth_self: 0
+go_to_market: 0
+go_to_market_self: 0
+quality: 0
+quality_self: 0
+delivery: 0
+delivery_self: 0
+user_insight: 0
+user_insight_self: 0
+data_intuition: 0
+data_intuition_self: 0
+# --- End management fields ---
 sources: []  # [{url: "https://...", type: "confluence|gdoc|github-repo|csv|markdown|manual", synced_at: YYYY-MM-DD}]
 updated_at: YYYY-MM-DD
 updated_by: ""
@@ -39,6 +69,40 @@ Member of [[squad-name]].
 
 - [[YYYY-MM-type-slug]] — brief description
 
+<!-- ============================================================
+     MANAGEMENT SECTIONS — Include ONLY when management_role is set.
+     Remove this entire block for non-managed persons.
+     ============================================================ -->
+
+---
+
+## Próximo 1:1
+
+> [!todo] Pauta acumulada para o próximo 1:1
+> Itens adicionados automaticamente via daily dump, reuniões ou notas rápidas.
+
+- [ ] %%vazio — novos itens serão adicionados aqui%%
+
+---
+
+## Temas em Acompanhamento
+
+%%Temas ativos que precisam de follow-up recorrente%%
+
+---
+
+## Desenvolvimento / PDI
+
+---
+
+## Log
+
+%%Registro corrido de observações, feedbacks e contexto relevante. Mais recente no topo.%%
+
+<!-- ============================================================
+     END MANAGEMENT SECTIONS
+     ============================================================ -->
+
 ---
 
 ## Expected Bidirectional Links
@@ -50,5 +114,6 @@ Member of [[squad-name]].
 | Person → Team | `[[squad-name]]` | `team` in frontmatter |
 | Person → Actor | `[[repo-name]]` | "Focal Points" section |
 | Person → Topic | `[[YYYY-MM-type-slug]]` | "Active Topics" section |
+| Person → Manager | `[[manager-slug]]` | `manager` in frontmatter (management only) |
 | Team → Person | `[[first-last]]` | `members` in Team frontmatter |
 | Topic → Person | `[[first-last]]` | `people` in Topic frontmatter |

--- a/templates/teams/_template.md
+++ b/templates/teams/_template.md
@@ -45,6 +45,28 @@ tags: [type/team]  # + domain/{payments,finance,notifications,checkout,orders,in
 - Jira Board: [link]()
 - Confluence Space: [link]()
 
+<!-- ============================================================
+     MANAGEMENT SECTIONS — Optional. Useful for product-management vaults
+     where teams track strategic themes and decisions over time.
+     ============================================================ -->
+
+---
+
+## Temas Estratégicos
+
+<!-- Strategic themes actively being tracked by the team. Append-only. -->
+
+---
+
+## Decisões Importantes
+
+| Data | Decisão | Contexto |
+|---|---|---|
+
+<!-- ============================================================
+     END MANAGEMENT SECTIONS
+     ============================================================ -->
+
 ---
 
 ## Expected Bidirectional Links


### PR DESCRIPTION
Closes #3

## Spec
- #2

## Summary

Estende templates e entity definitions para suportar workflows de gestão de produto (GPM/PM) sem quebrar compatibilidade com o framework original.

### Mudanças

**templates/people/_template.md:**
- Campo `management_role` (direct-report, indirect-report, peer, leader, external)
- Campo `manager` (wikilink para o gestor)
- 24 campos de competência Reforge (12 regulares + 12 self, escala 0-5)
- Seções: Próximo 1:1 (com placeholder %%vazio%%), Temas em Acompanhamento, Desenvolvimento/PDI, Log
- Seções condicionais — só incluir quando management_role está definido

**templates/teams/_template.md:**
- Seção "Temas Estratégicos" (append-only)
- Seção "Decisões Importantes" (tabela Data/Decisão/Contexto)

**templates/discussions/_template.md:**
- action_items como objetos estruturados: {description, owner, status, deadline, routed_to}

**entities/person.md:**
- Documentação de management fields, competency model, write rules para seções de 1:1

**entities/team.md:**
- Documentação de management sections (Temas Estratégicos, Decisões Importantes)

## Checklist
- [x] Template person com seções de 1:1 condicionais
- [x] Template person com 24 campos de competência
- [x] Template team com Temas Estratégicos e Decisões
- [x] Template discussion com action_items estruturados
- [x] Entity definitions atualizadas
- [x] Person sem management_role renderiza identicamente ao original