### PR TITLE
chore: recupera 3 skills que viviam só no cache local

### DIFF
--- a/skills/analyze-call/SKILL.md
+++ b/skills/analyze-call/SKILL.md
@@ -1,0 +1,470 @@
+---
+name: analyze-call
+description: >
+  Behavioral analysis of a single meeting/call. Extracts conversational dynamics
+  (turn-taking, interruptions, % of speech), linguistic patterns per speaker,
+  observable competence signals, and suggested next-1:1 follow-ups. Output is
+  curated observations appended to the Log of the relevant person notes — never
+  raw transcript. Default mode is interactive (always confirms before persisting).
+  Use when: "bedrock analyze-call", "/bedrock:analyze-call",
+  "analisa a call de hoje com X", "analisa essa reunião", "análise comportamental",
+  or when the user wants to extract behavioral patterns from a specific meeting.
+user_invocable: true
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, Agent, ToolSearch, WebFetch, mcp__granola__*
+---
+
+# /bedrock:analyze-call — Behavioral Analysis of a Single Call
+
+## Plugin Paths
+
+Same convention as other Bedrock skills. `<base_dir>` is provided at invocation.
+
+- Entity definitions: `<base_dir>/../../entities/`
+- Templates: `<base_dir>/../../templates/{type}/_template.md`
+- Plugin CLAUDE.md: `<base_dir>/../../CLAUDE.md` (auto-injected)
+
+---
+
+## Vault Resolution
+
+Same chain as other Bedrock skills:
+
+1. `--vault <name>` flag → registry lookup
+2. CWD detection → registered vault path match
+3. Default vault from registry
+4. Error if no vault found
+
+From this point: `VAULT_PATH` is the resolved vault root.
+
+---
+
+## Overview
+
+This skill analyzes ONE specific call/meeting for **behavioral coaching purposes** —
+not for ingestion. It runs alongside `/bedrock:granola` (which handles fluxo padrão
+of meetings) and complements it.
+
+**You are a coaching analysis agent.** Follow the phases below in order.
+
+**Hard rules (read these first):**
+
+1. Output is **observations**, not judgments. Never write "X is arrogant". Always anchor:
+   "On 2026-05-04 in call X, interrupted Y three times during the explanation of Z".
+2. **Never persist literal transcript** in the vault. Only curated observations.
+3. Default mode is **interactive** — always show analysis to user and ask for
+   confirmation before persisting. Never write to vault silently.
+4. Output is **private to the vault owner**. Mark every entry with
+   `<!-- private: coaching -->` on the first content line.
+5. Transcripts are noisy. Treat conclusions as preliminary. Avoid quoting literal
+   phrases (they often contain transcription errors). Describe patterns instead.
+6. If uncertain about a pattern (single occurrence, low signal), say so explicitly.
+
+---
+
+## Phase 0 — Parse Arguments
+
+Skill is invoked as:
+
+```
+/bedrock:analyze-call [SOURCE] [REFERENCE] [--focus <person-slug>] [--draft] [--no-self]
+```
+
+Or in natural language ("analisa a call de hoje com o Cannuto"). Parse intent:
+
+- **SOURCE** ∈ {`granola`, `gdoc`, `last`, auto-detect from natural language}
+- **REFERENCE** depends on source:
+  - granola: meeting UUID OR title fragment (skill will search via list_meetings)
+  - gdoc: full URL of a Google Doc containing the Meet transcript
+  - last: no reference; fetch most recent meeting from Granola today
+- **--focus**: person slug to focus the analysis on. Default: all managed people in the call.
+- **--draft**: do not persist; only show analysis output.
+- **--no-self**: skip auto-analysis of the vault owner. Default: include.
+
+If args ambiguous, ask one grouped clarification question before proceeding.
+
+---
+
+## Phase 1 — Fetch Transcript via Adapter
+
+### 1.1 Granola adapter
+
+Verify MCP availability:
+
+```
+ToolSearch(query: "select:mcp__granola__list_meetings,mcp__granola__get_meeting_transcript,mcp__granola__get_meetings", max_results: 3)
+```
+
+If MCP unavailable: graceful error and stop.
+
+**Resolve meeting:**
+- If UUID provided → use directly
+- If title fragment → `mcp__granola__list_meetings(time_range: "this_week")`, fuzzy match
+- If `last` → list this_week, take most recent (sort by date desc)
+- If multiple matches → ask user to disambiguate
+
+**Fetch transcript and metadata:**
+
+```
+transcript = mcp__granola__get_meeting_transcript(meeting_id: <uuid>)
+details = mcp__granola__get_meetings(meeting_ids: [<uuid>])
+```
+
+`details` provides participants, title, date. Save these.
+
+### 1.2 GDoc adapter
+
+If source is `gdoc`:
+
+Delegate to `/bedrock:gdoc-to-markdown` skill (or call it as a sub-skill) with the URL.
+Returns markdown of the transcript. Then parse: identify speaker labels (Meet uses
+"Speaker Name HH:MM:SS" format).
+
+Get participants list from the doc header if present, or infer from speaker labels.
+
+### 1.3 Length sanity check
+
+If transcript is shorter than ~10 minutes of content (approx <2000 words):
+warn user that confidence is low. Offer to abort.
+
+---
+
+## Phase 2 — Load Vault Context
+
+Same as `/bedrock:granola` Phase 3, but only what's needed for behavioral analysis:
+
+1. **Vault owner identity:** read `<VAULT_PATH>/people/` to find the entry where
+   `aliases` includes the user's name from config, OR `management_role: "self"`.
+   Save as `OWNER_SLUG`.
+2. **Managed people:** Glob `<VAULT_PATH>/people/*.md` filtered by
+   `management_role` ∈ {`direct-report`, `indirect-report`}. Build alias lookup.
+3. **Reforge competency definitions** (optional context for signal mapping):
+   read from vault if present in `Desenvolvimento/` folder.
+
+---
+
+## Phase 3 — Normalize Speakers
+
+Map each transcript turn to a known person slug.
+
+### 3.1 Granola normalization
+
+Granola transcripts use `Me:` (vault owner) and `Them:`.
+
+- **1:1 (exactly 2 known participants):** "Me" → `OWNER_SLUG`. "Them" → resolve
+  the OTHER participant via alias map. **Proceed.**
+- **Group meeting (3+ known participants):** "Them" is ambiguous — multiple
+  people share the label. **STOP and ask user:**
+  > "Granola não distingue speakers em reuniões de grupo (todos viram 'Them').
+  > Posso fazer uma análise da dinâmica geral (% Pedro x % grupo, padrões seus
+  > apenas), mas não consigo atribuir comportamentos individuais a cada
+  > participante. Prosseguir mesmo assim, ou prefere usar GDoc/Meet transcript?"
+
+### 3.2 GDoc/Meet normalization
+
+Meet uses real names. For each speaker label:
+
+1. Match against the alias map of vault people.
+2. If match → use the person slug.
+3. If no match → mark as `external:<Name>` (no entity created, no persistence
+   for this speaker).
+
+---
+
+## Phase 4 — Run Analysis
+
+For each known speaker (vault owner + focused person(s)), compute:
+
+### 4.1 Conversational dynamics (across all speakers)
+
+- Approximate share of speech (word count per speaker as % of total).
+- Number of speaker turns.
+- Interruption count and direction (X→Y means X cut Y mid-thought).
+- Question count per speaker (turns ending in `?` or starting with question
+  patterns: "você", "como", "por que", "será que", etc.).
+
+### 4.2 Linguistic patterns per speaker
+
+- **Hedging frequency:** "acho", "talvez", "sei lá", "tipo", "meio que".
+- **Assertiveness markers:** declarative sentences without hedging vs hedged statements.
+- **Justification before request:** does the speaker explain the rationale before
+  asking for input? (pattern of "blindagem")
+- **Topic-shift initiation:** who starts new topics?
+- **Validation seeking:** "faz sentido?", "concorda?", "está ok?".
+
+### 4.3 Behavioral signals (only if clearly observable)
+
+Map to Reforge Product Competency Model dimensions when there is **explicit
+evidence**:
+
+- Communication / Fluency
+- Strategic thinking
+- Execution
+- Discovery
+- Quality
+
+If signal is weak or single-occurrence, do **not** report it.
+
+**Reforge as canonical source for vocabulary.** When mapping a signal to a
+sub-competency or to a leadership pattern (e.g., "directive vs supportive",
+"managing up", "stakeholder calibration"), validate the term against the
+Reforge material in
+`<VAULT_PATH>/Desenvolvimento/reforge-product-leadership.md`.
+
+**How to consult (do NOT load the file into context):** the file is ~115k
+words. Use targeted grep instead:
+
+```bash
+grep -n -B 2 -A 8 "<term>" <VAULT_PATH>/Desenvolvimento/reforge-product-leadership.md
+```
+
+Useful pivot terms: "directive leadership", "supportive leadership",
+"feedback", "coaching conversation", "performance management", "team
+archetype", "Product Leader Canyon", "managing up", "stakeholder".
+
+When citing a Reforge concept in the analysis output, reference it in passing
+("padrão típico de directive leadership leaning"); do not copy the source
+material into the Log entry.
+
+### 4.4 Friction / repetition
+
+- Topics where speakers disagreed and didn't reconcile.
+- Topics where the vault owner had to repeat themselves to be understood.
+- Topics that the focused person evaded or deflected.
+
+### 4.5 Suggested next-1:1 items
+
+- Items that came up in the call but weren't fully resolved.
+- Behavioral feedback that the owner might want to deliver.
+- Things the focused person offered (help, opinion) that the owner accepted/declined.
+
+---
+
+## Phase 4.6 — Pattern Check Across Previous Analyses
+
+**Goal:** Detect whether observations from the current call repeat patterns from
+prior `[análise]` entries in the same person's Log. Surfaces recurring behavior
+that warrants a Tema em Acompanhamento.
+
+### 4.6.1 Fetch prior analyses
+
+For each person being analyzed (focused person + owner):
+
+```bash
+# Read the person's Log section and extract all [análise] entries
+grep -n '^### [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\} — \[análise\]' \
+  <VAULT_PATH>/people/<person-slug>.md
+```
+
+For each match found, extract the entry block (from header until next `### `
+header or end of `## Log` section). Sort by date desc, take the **last 5 entries
+maximum**. Skip the current call (if already written, by source ID).
+
+If fewer than **2 prior entries** exist for the person: pattern check is
+**skipped** (not enough signal). State this in the output: "Pattern check
+pulado: histórico insuficiente (<2 análises prévias)."
+
+### 4.6.2 Semantic comparison
+
+For each observation in the current analysis (Phase 4.2 to 4.4), compare against
+observations in prior entries. **Use semantic equivalence, not string match**:
+
+- "justifica antes de pedir input" ≈ "blindagem com 4 argumentos antes da pergunta"
+- "recusou ajuda sem destrinchar" ≈ "fechou oferta do Mac antes de explorar"
+- "interrompeu durante explicação técnica" ≈ "cortou no meio do raciocínio"
+
+Two observations are the same pattern if they describe the same underlying
+behavior, even if phrased differently. The LLM doing the comparison should err
+toward **conservative matching** — when in doubt, don't merge.
+
+### 4.6.3 Threshold
+
+A pattern is **flagged as recurring** when it appears in ≥2 distinct analyses
+(including the current one). Strong patterns: ≥3 occurrences.
+
+### 4.6.4 Output structure
+
+Add a new section to the rendered analysis (Phase 5) for each person:
+
+```markdown
+**Padrões recorrentes detectados:**
+- [3x] {pattern description} ({date1}, {date2}, {date3})
+- [2x] {pattern description} ({date1}, {date2})
+```
+
+If no pattern was flagged: omit the section entirely (don't show empty).
+
+### 4.6.5 Limits and guards
+
+- **Max 5 entries** read per person (window size). Don't try to compare against
+  the entire history — costs grow and signal degrades.
+- **Conservative clustering.** If you're uncertain whether two observations
+  describe the same pattern, treat them as distinct.
+- **Don't claim trends from 2 occurrences alone.** Mark as "[2x] possível padrão".
+  Reserve "[3x]" or higher for confident calls.
+- **Don't infer causation.** "Cannuto cortou Carol em 3 calls" is observation,
+  not "Cannuto desrespeita Carol".
+- **Vocabulary drift:** if the user describes the same pattern with different
+  words across analyses, the LLM should still cluster them. Document the
+  consolidated phrasing in the output.
+
+---
+
+## Phase 5 — Render Output
+
+For each person to be written about (focused person(s) + optionally owner),
+render a Log entry in this exact format:
+
+```markdown
+### YYYY-MM-DD — [análise] {meeting title} ({source}:{id})
+<!-- private: coaching -->
+
+**Dinâmica:** {OWNER_NAME} ~X% / {OTHER_NAME} ~Y% da fala, N interrupções
+
+**Observações sobre {OTHER_NAME}:**
+- {pattern 1, anchored in evidence}
+- {pattern 2, anchored in evidence}
+
+**Padrões meus na call:** *(only in OWNER's note)*
+- {self-observation 1}
+- {self-observation 2}
+
+**Padrões recorrentes detectados:** *(omit section if none)*
+- [3x] {pattern description} ({date1}, {date2}, {date3})
+- [2x] {pattern description} ({date1}, {date2})
+
+**Sinais de competências (preliminar, não atualizar score):**
+- {OTHER_NAME}: {dimension} {score-suggestion} — {evidence}
+
+**Pra próximo 1:1:**
+- [ ] {follow-up item} *(YYYY-MM-DD)*
+```
+
+Notes:
+
+- Header format is **fixed** for parseability: `### YYYY-MM-DD — [análise] <title> (<source>:<id>)`.
+- The `[análise]` prefix is the marker that future aggregation skills will use to filter.
+- The `<source>:<id>` enables traceability and dedup (`granola:c82110d9-...` or `gdoc:1AbCd...`).
+- Suggested 1:1 items use the same format as `/bedrock:dump` so they merge naturally.
+
+---
+
+## Phase 6 — Interactive Confirmation
+
+Default flow (always interactive unless `--draft` is set):
+
+1. Show the rendered analysis to the user.
+2. Ask explicit questions in this order:
+   - **"Gravar essas observações no Log de {pessoa}? (sim / não / editar)"**
+   - **"Adicionar item ao Próximo 1:1 de {pessoa}? (sim / não / editar)"**
+   - **For each recurring pattern detected (Phase 4.6):**
+     **"Padrão '{descrição}' apareceu em {N} análises. Adicionar em Temas em Acompanhamento de {pessoa}? (sim / não / editar)"**
+   - **"Gravar análise sobre você em `pedro-monteiro.md`? (sim / não)"** *(only if --no-self was not passed)*
+3. If user says "editar", let them dictate the changes inline before persisting.
+4. If user says "não" to all → respond "OK, nada foi gravado." and stop.
+
+---
+
+## Phase 7 — Persist via /bedrock:preserve
+
+Build structured input for `/bedrock:preserve`. Each block goes to the **Log**
+section (route_to: log). The header date is the meeting date; the marker is
+included in the content body.
+
+```yaml
+entities:
+  - type: person
+    name: "{focused person name}"
+    action: update
+    route_to: log
+    content: |
+      [análise] {meeting title} ({source}:{id})
+      <!-- private: coaching -->
+
+      **Dinâmica:** ...
+      **Observações:** ...
+      **Sinais de competências (preliminar):** ...
+      **Pra próximo 1:1:** ...
+    date: "YYYY-MM-DD"
+
+  - type: person
+    name: "{focused person name}"
+    action: update
+    route_to: proximo_1_1
+    content: "{follow-up item from analysis}"
+    date: "YYYY-MM-DD"
+
+  - type: person
+    name: "{focused person name}"  # only when user confirmed adding pattern to Temas em Acompanhamento
+    action: update
+    route_to: temas_em_acompanhamento
+    content: |
+      ### Coaching: {pattern description}
+      <!-- private: coaching -->
+      Padrão observado em {N} análises ({date1}, {date2}, ...). {brief context}.
+    date: "YYYY-MM-DD"
+
+  - type: person
+    name: "Pedro Monteiro"  # only if --no-self was not passed and self-section has content
+    action: update
+    route_to: log
+    content: |
+      [análise] {meeting title} ({source}:{id})
+      <!-- private: coaching -->
+
+      **Padrões meus:** ...
+    date: "YYYY-MM-DD"
+```
+
+Delegate to `/bedrock:preserve`.
+
+**Important:** the Log entry header MUST follow the format
+`### YYYY-MM-DD — [análise] {title} ({source}:{id})`. This is enforced because
+future aggregation skills depend on it. If `/bedrock:preserve` strips or alters
+the format, fix the rendering before invoking.
+
+---
+
+## Phase 8 — Summary
+
+Present a compact summary to the user:
+
+```
+Análise gravada:
+- Log de [[rodrigo-cannuto]] → 1 entrada [análise]
+- Próximo 1:1 de [[rodrigo-cannuto]] → 2 itens
+- Temas em Acompanhamento de [[rodrigo-cannuto]] → 1 padrão recorrente registrado
+- Log de [[pedro-monteiro]] → 1 entrada [análise] (auto-coaching)
+
+Pattern check: {N entradas prévias lidas, M padrões recorrentes detectados}.
+
+Confiança: {alta / média / baixa} — transcrição com {N} marcadores de ruído
+detectados ({pequenos exemplos}).
+
+Fonte: {granola:uuid | gdoc:url}
+```
+
+---
+
+## Rules (recap)
+
+1. **Default mode is interactive.** Never persist without user confirmation.
+2. **Anchored observations only.** No absolute judgments. Each statement has
+   evidence (interruption count, % of speech, repeated pattern).
+3. **No literal transcript in the vault.** Only curated observations.
+4. **Privacy marker on every entry.** `<!-- private: coaching -->` first content line.
+5. **Header format is fixed** for aggregation: `### YYYY-MM-DD — [análise] {title} ({source}:{id})`.
+6. **Group meetings via Granola → ask before proceeding.** Granola can't distinguish
+   speakers in groups; offer to switch to Meet transcript via GDoc, or proceed with
+   group-level dynamics only.
+7. **Low-confidence signals are suppressed.** Only report a behavioral signal when
+   it occurs more than once or is unambiguous.
+8. **Language:** match vault config (Portuguese here). Frontmatter keys stay in English.
+9. **No auto-update of competency scores.** Only suggestions, marked "preliminar".
+10. **Graceful degradation** when MCP/GDoc adapter fails: inform user and stop.
+11. **Pattern check window:** read ≤5 prior `[análise]` entries per person.
+    Skip pattern check if <2 prior entries exist. Threshold for flagging: ≥2
+    occurrences (including current call). "Possível padrão" for [2x],
+    "padrão recorrente" for [3x]+.
+12. **Patterns become Temas em Acompanhamento only after user confirmation.**
+    Never auto-promote a recurring observation. The Tema entry includes the
+    privacy marker and references source dates for traceability.

--- a/skills/catch-up/SKILL.md
+++ b/skills/catch-up/SKILL.md
@@ -1,0 +1,377 @@
+---
+name: catch-up
+description: >
+  Orchestrates "process the day" by discovering and processing unprocessed items
+  across all input sources: daily fleeting note, Drive transcripts (Gemini Meet
+  captures saved by /transcricoes), and Granola meetings (via MCP). Dedupes
+  Drive vs Granola for the same meeting (Drive wins), and routes everything via
+  /bedrock:preserve in a single coordinated run.
+  Use when: "bedrock catch-up", "bedrock-catch-up", "/bedrock:catch-up",
+  "processa o dia", "processar o dia", "catch-up", "processar tudo do dia".
+user_invocable: true
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, Agent, ToolSearch, mcp__granola__*
+---
+
+# /bedrock:catch-up — Day Catch-up Orchestrator
+
+## Plugin Paths
+
+Entity definitions and templates are in the plugin directory, not the vault root.
+Use the "Base directory for this skill" provided at invocation to resolve paths:
+
+- Entity definitions: `<base_dir>/../../entities/`
+- Templates: `<base_dir>/../../templates/{type}/_template.md`
+- Plugin CLAUDE.md: `<base_dir>/../../CLAUDE.md` (auto-injected into context)
+
+---
+
+## Vault Resolution
+
+Same resolution chain as other skills:
+
+1. `--vault <name>` flag → registry lookup at `<base_dir>/../../vaults.json`
+2. CWD detection → registered vault path match
+3. Default vault from registry
+4. Error if no vault found
+
+Set `VAULT_PATH` accordingly.
+
+---
+
+## Overview
+
+This skill is a **discovery + orchestration** layer. It does NOT reimplement
+classification or routing — it discovers unprocessed sources for a given date,
+presents a plan, and delegates each source to the appropriate sub-skill or to
+`/bedrock:preserve` directly.
+
+**You are an orchestration agent.** Follow phases below in order. Do NOT skip
+the planning phase: always show the user what was found before executing.
+
+---
+
+## Phase 0 — Parse Input
+
+Parse the user's input to determine the target date:
+
+| Input | Resolution |
+|---|---|
+| (empty) or "hoje" | Today's date |
+| "ontem" | Yesterday |
+| `YYYY-MM-DD` | Use literally |
+| Relative like "anteontem" or "-N" | Compute from today |
+
+Set `DATE` to resolved value in `YYYY-MM-DD` format.
+
+---
+
+## Phase 1 — Discovery
+
+Run all three discovery steps in parallel (they are independent).
+
+### 1.1 — Daily fleeting
+
+Check whether `<VAULT_PATH>/fleeting/<DATE>-daily.md` exists.
+
+If yes, read its frontmatter:
+- `status: raw` (or `reviewing`) → mark `daily.state = "raw"`, capture path
+- `status: promoted` → mark `daily.state = "already_processed"`
+- Other / no status → treat as raw
+
+If file does not exist → `daily.state = "missing"`.
+
+### 1.2 — Drive transcripts
+
+Read vault config:
+```bash
+cat <VAULT_PATH>/.bedrock/config.json
+```
+
+Field `transcripts_dir`. If absent or empty → skip Drive source entirely
+(`drive.state = "not_configured"`).
+
+If configured, scan that directory for `*.md` files. For each file with
+frontmatter `data: <DATE>`, check the `processed_by_dump` field:
+
+```bash
+# Cheap membership check via shell (do NOT cat files into context)
+for f in "<transcripts_dir>"/*.md; do
+  data=$(grep -m1 '^data:' "$f" | awk '{print $2}')
+  if [ "$data" = "<DATE>" ]; then
+    if grep -q '^processed_by_dump: true' "$f"; then
+      echo "PROCESSED|$f"
+    elif grep -q '^skip: true' "$f"; then
+      echo "SKIP|$f"
+    else
+      echo "PENDING|$f"
+    fi
+  fi
+done
+```
+
+Build `drive_pending`: list of `{path, hora_inicio, doc_id, titulo}` for each
+PENDING file. Parse `hora-inicio` from frontmatter and the original meeting
+title from the body's first heading.
+
+### 1.3 — Granola meetings
+
+Check Granola MCP availability:
+
+```
+ToolSearch(query: "select:mcp__granola__list_meetings,mcp__granola__get_meetings", max_results: 3)
+```
+
+If tools NOT found → `granola.state = "not_available"`.
+
+If found, call:
+```
+mcp__granola__list_meetings(time_range: "this_week")
+```
+
+Filter results to meetings whose start date matches `<DATE>`.
+
+Cross-check against `<VAULT_PATH>/granola-processados.md` using shell grep
+(never load the file into context):
+
+```bash
+# For each candidate ID
+grep -qF "$ID" <VAULT_PATH>/granola-processados.md && echo "ALREADY" || echo "PENDING"
+```
+
+Build `granola_pending`: list of `{id, hora_inicio, titulo}` for each PENDING meeting.
+
+### 1.4 — Dedupe Drive ↔ Granola
+
+For each meeting in `granola_pending`, check if `drive_pending` has an entry
+with the same `data` and `hora_inicio` within ±5 minutes.
+
+If yes → remove from `granola_pending` (mark as `deduped_by_drive`).
+
+**Drive wins.** Granola is fallback only for meetings without a Drive capture.
+
+---
+
+## Phase 2 — Present Plan
+
+Show the user a summary BEFORE executing:
+
+```
+Catch-up para <DATE>:
+
+  Daily fleeting:
+    <state and path, or "missing" or "already processed">
+
+  Drive transcripts (transcripts_dir):
+    <N pending> | <M already processed> | <K skip>
+    [list pending with hora and title, if any]
+
+  Granola meetings:
+    <N pending> | <M deduped by Drive> | <K already processed>
+    [list pending with hora and title, if any]
+    [list deduped entries for transparency]
+
+Vou processar nesta ordem: Drive → Granola (resto) → Daily.
+
+Confirmar? (sim / pular X / cancelar)
+```
+
+Wait for confirmation. The user may:
+- "sim" → proceed
+- "pular drive" / "pular daily" / "pular granola" → exclude a source
+- "cancelar" → stop
+
+---
+
+## Phase 3 — Load Vault Context (once, shared across sub-processes)
+
+Load the alias map and entity lookups once. They will be reused by all sub-steps.
+
+1. **People with management_role:** Glob `<VAULT_PATH>/people/*.md`, read frontmatter, build:
+   `{filename, name, aliases[], management_role, team}`.
+2. **Teams:** Glob `<VAULT_PATH>/teams/*.md`, read frontmatter.
+3. **Active projects:** Glob `<VAULT_PATH>/projects/*.md` where `status != "completed"`.
+4. **Alias map:** case-insensitive: alias → person_filename.
+
+---
+
+## Phase 4 — Execute
+
+### 4.1 — Drive transcripts
+
+For each file in `drive_pending` (chronological order by `hora-inicio`):
+
+1. **Read the file** — full body has `# {original title}` then plain-text export
+   (Observações + Transcrição sections).
+
+2. **Detect 1:1 vs group** — same heuristics as `/bedrock:granola` Phase 4:
+   - Parse participants from the Observações section (Gemini lists them) and
+     from the title (e.g., "Fulano / Monteiro" → 2 participants).
+   - If exactly 2 known participants and the other is a managed person
+     (`direct-report` / `indirect-report`) OR title pattern `1:1`,
+     `X <> Y`, `X / Y` → **1:1**.
+   - Otherwise → **group**.
+
+3. **Classify content** — extract from Observações (Gemini already produces a
+   summary + action items):
+   - Action items for managed people → `proximo_1_1`
+   - Action items for the vault owner → owner's to-do
+   - Observations about people (1:1 only) → person `log`
+   - Team decisions → team `decisao`
+   - Project updates → project body
+
+4. **Build /bedrock:preserve input:**
+   - For 1:1: `person` updates (log + proximo_1_1)
+   - For group: `discussion` create entity + routed people/team/project updates
+   - Discussion slug: lowercase, no accents, spaces→hyphens, from title (max 50 chars)
+
+5. **Delegate to `/bedrock:preserve`** via Skill tool.
+
+6. **Mark file as processed** — append to its frontmatter (or edit in place):
+   ```yaml
+   processed_by_dump: true
+   processed_by_dump_at: <today YYYY-MM-DD>
+   ```
+
+   Use `Edit` to flip `processed_by_dump: false` → `processed_by_dump: true`
+   and add `processed_by_dump_at`. Never overwrite the body.
+
+### 4.2 — Granola (only meetings NOT deduped)
+
+If `granola_pending` is non-empty AND user did not skip Granola:
+
+Invoke `/bedrock:granola` via Skill tool. The granola skill will fetch its own
+unprocessed list (which already excludes IDs in `granola-processados.md`) and
+process them. Our dedupe (Phase 1.4) acted only as a planning aid; the actual
+re-processing protection lives in granola-processados.md.
+
+**Important:** if Phase 1.4 marked specific IDs as `deduped_by_drive`, append
+them to `granola-processados.md` BEFORE invoking `/bedrock:granola`, so that
+skill skips them:
+
+```bash
+for ID in <deduped_ids>; do
+  echo "$ID" >> <VAULT_PATH>/granola-processados.md
+done
+```
+
+This is critical to avoid double-processing.
+
+### 4.3 — Daily fleeting
+
+If `daily.state == "raw"`:
+
+Invoke `/bedrock:dump` via Skill tool with the resolved daily file path. The
+dump skill handles its own classification, routing, and `status: promoted`
+marking.
+
+If `daily.state == "missing"` or `"already_processed"`: skip silently (mention
+in summary).
+
+---
+
+## Phase 5 — Aggregate Summary
+
+After all sub-steps complete, combine their summaries:
+
+```
+Catch-up <DATE> concluído.
+
+Drive (N transcrições):
+  - <titulo curto> (1:1 com Fulano) → log + 2 items próximo 1:1
+  - <titulo curto> (grupo) → discussion + 3 routings
+
+Granola (M reuniões processadas, K deduped pelo Drive):
+  - <delegado pra /bedrock:granola, sumário abaixo>
+
+Daily fleeting:
+  - <delegado pra /bedrock:dump, sumário abaixo>
+
+Distribuição total:
+  - X itens → Próximo 1:1
+  - Y observações → Log
+  - Z decisões → Teams
+  - W updates → Projects
+  - ⚠️ N incertos
+```
+
+---
+
+## Phase 6 — Offer Behavioral Analysis
+
+After Phase 5 summary, identify Drive 1:1 transcripts processed in this run that
+are candidates for `/bedrock:analyze-call`. Granola 1:1s are NOT considered here —
+the granola skill has its own offer mechanism that fires after `/bedrock:granola`
+completes; do not double-offer.
+
+### 6.1 — Build candidate list
+
+From Drive transcripts processed in Phase 4.1, select files classified as `1:1`.
+For each, look up the OTHER participant (not the vault owner) in `<VAULT_PATH>/people/`:
+
+| Other participant's `management_role` | Default selection | Show as candidate? |
+|---|---|---|
+| `direct-report` | **default-on** | yes |
+| `indirect-report` | **default-on** | yes |
+| `peer` | default-off | yes (user can opt-in) |
+| `leader` | default-off | yes (analyzing being-coached dynamics) |
+| `external`, `self`, `offboarded` | n/a | skip |
+
+For each candidate, enrich with prior-analysis context (cheap shell grep, do NOT
+load Log into context):
+
+```bash
+# Count of prior [análise] entries (≥0)
+grep -c '^### .* — \[análise\]' <VAULT_PATH>/people/<slug>.md 2>/dev/null
+
+# Date of most recent prior analysis (or "nenhuma")
+grep -m1 '^### .* — \[análise\]' <VAULT_PATH>/people/<slug>.md | awk '{print $2}' 2>/dev/null
+```
+
+### 6.2 — Present batched offer
+
+Show ONE consolidated question (never per-file). Format:
+
+```
+N transcrições processadas, M são 1:1 elegíveis pra análise comportamental:
+  [x] <Nome> (<role>) — última análise: <YYYY-MM-DD ou "nenhuma">, <N> entries de [análise]
+  [ ] <Nome> (peer) — última análise: nenhuma
+  ...
+
+Rodar /bedrock:analyze-call em quais? (todas / nenhuma / lista de números, ou "x N" pra alternar)
+```
+
+### 6.3 — Execute (if user confirms)
+
+For each selected candidate, invoke `/bedrock:analyze-call` via Skill tool with the
+transcript file path as input. analyze-call handles its own write (Log entry with
+`<!-- private: coaching -->` marker) and the cross-call pattern detection (≥2
+ocorrências → propor tema em `## Temas em Acompanhamento`).
+
+If user replies "nenhuma" or empty: skip silently, no error.
+
+### 6.4 — Group meetings: never auto-offer
+
+Group meetings (3+ participants) are NEVER offered for analyze-call automatically.
+analyze-call on groups has limited value (everyone but vault owner is "Them" in
+Granola; in Drive transcripts behavioral signal dilutes across many speakers).
+User can run `/bedrock:analyze-call` manually on a specific group transcript when
+they explicitly want.
+
+---
+
+## Rules
+
+1. **Discovery is read-only.** Phase 1 never writes — it only inventories.
+2. **Plan before execute.** Always present Phase 2 and wait for confirmation,
+   unless user explicitly bypassed via flag (not currently supported).
+3. **Drive > Granola for dedupe.** ±5 min window on `data + hora-inicio`.
+4. **Idempotent.** Re-running on the same day must not re-process anything:
+   - Drive: respects `processed_by_dump: true` and `skip: true`
+   - Granola: respects `granola-processados.md` (deduped IDs added before delegation)
+   - Daily: respects `status: promoted`
+5. **Missing source ≠ error.** If `transcripts_dir` is not configured, or no
+   daily exists, or Granola MCP is offline — skip that source, continue with
+   the rest. Report what was skipped and why.
+6. **Membership checks via shell, not context.** Use `grep -qF` to test
+   processed-IDs and frontmatter flags. Never `cat` registries into the prompt.
+7. **Language** — use the vault's configured language for all output.

--- a/skills/granola/SKILL.md
+++ b/skills/granola/SKILL.md
@@ -68,25 +68,29 @@ Stop execution. Do NOT attempt to call Granola tools if they are not available.
 
 ---
 
-## Phase 1 — Load Processed IDs
+## Phase 1 — Ensure Registry Exists
 
-Read the registry of already-processed meeting IDs:
+Make sure the processed-IDs registry file exists. **Do NOT load its contents
+into context.** Membership checks happen later via `grep` (Phase 2.2).
 
 ```bash
-cat <VAULT_PATH>/granola-processados.md 2>/dev/null
-```
-
-If the file does not exist, create it:
-
-```markdown
+REGISTRY="<VAULT_PATH>/granola-processados.md"
+if [ ! -f "$REGISTRY" ]; then
+  cat > "$REGISTRY" <<'HEAD'
 # Granola — Reuniões Processadas
 
 Lista de IDs de reuniões do Granola já processadas no vault.
 Um ID por linha. Não editar manualmente.
 
+HEAD
+fi
 ```
 
-Parse all UUIDs from the file into a set: `PROCESSED_IDS`.
+**Why grep instead of cat-into-context:** the file grows unbounded over time
+(potentially thousands of IDs after a year). Loading it into the LLM context
+inflates token usage with no benefit, and slicing the read with `head`/`tail`
+risks missing IDs that happen to land outside the slice (this caused a bug
+on 2026-05-05). `grep -qF` is O(file size) on disk but O(1) on context.
 
 ---
 
@@ -106,11 +110,26 @@ If `this_week` returns 0 meetings, also try:
 mcp__granola__list_meetings(time_range: "last_week")
 ```
 
-### 2.2 Filter unprocessed
+### 2.2 Filter unprocessed (membership via grep)
 
-From the listed meetings, remove any whose ID appears in `PROCESSED_IDS`.
+For each meeting ID returned by `list_meetings`, run a fixed-string grep
+against the registry. **Do not parse the file into the LLM context.** The
+shell does the membership check; only the result (processed/unprocessed) is
+exposed to the model.
 
-If no unprocessed meetings remain: respond "Nenhuma reunião nova para processar." and stop.
+```bash
+for id in <id1> <id2> ... <idN>; do
+  if grep -qF "$id" "$REGISTRY"; then
+    echo "skip $id"
+  else
+    echo "process $id"
+  fi
+done
+```
+
+Build the list `UNPROCESSED_IDS` from the IDs that printed `process`.
+
+If `UNPROCESSED_IDS` is empty: respond "Nenhuma reunião nova para processar." and stop.
 
 ### 2.3 Fetch details
 
@@ -242,15 +261,90 @@ Delegate to `/bedrock:preserve`.
 
 ---
 
-## Phase 6 — Register Processed IDs
+## Phase 5.5 — Offer Behavioral Analysis (analyze-call hook)
 
-After successfully processing each meeting, append its ID to the registry:
+After ingestion completes (Phase 5), identify which processed meetings qualify
+for behavioral analysis via `/bedrock:analyze-call`. The goal is coaching:
+extract patterns from 1:1s with managed people that the standard summary
+misses.
 
-```bash
-echo "<meeting_uuid>" >> <VAULT_PATH>/granola-processados.md
+### 5.5.1 Eligibility filter
+
+For each processed meeting, classify into one of three buckets:
+
+| Bucket | Criteria |
+|---|---|
+| **Auto-eligible** (default: include) | 1:1 with a person whose `management_role` is `direct-report` or `indirect-report` |
+| **Optional** (default: exclude, ask) | 1:1 with a person whose `management_role` is `peer` (e.g., Mac) |
+| **Skip** | Group meetings (Granola can't distinguish speakers in groups), 1:1s with external people, meetings with no transcript or summary too short (<2000 words estimated) |
+
+### 5.5.2 Present batch question
+
+If at least one meeting is auto-eligible OR optional, ask the user **once**:
+
+```
+Análise comportamental disponível para {N} reunião(ões):
+
+  Auto-elegíveis (1:1 com liderado):
+    - "{título}" → {pessoa} ({direct-report|indirect-report})
+    - ...
+
+  Opcionais (1:1 com peer):
+    - "{título}" → {pessoa} (peer)
+
+Rodar análise comportamental?
+  [s] Sim — todas auto-elegíveis (default)
+  [t] Sim — todas, incluindo peers
+  [n] Não — pular análise nesta rodada
+  [c] Customizar — escolher uma a uma
 ```
 
-One ID per line. Append only — never remove or rewrite the file.
+If zero meetings are auto-eligible AND zero are optional: skip Phase 5.5
+silently (don't ask anything, just proceed to Phase 6).
+
+### 5.5.3 Invoke analyze-call per selected meeting
+
+For each meeting selected by the user, invoke `/bedrock:analyze-call`:
+
+```
+/bedrock:analyze-call granola <meeting_uuid>
+```
+
+Each invocation runs in **interactive mode** (its own confirmation flow per
+person/log entry). Do NOT bypass `/bedrock:analyze-call`'s own guard-rails —
+the user still confirms each Log entry. The Phase 5.5 batch question is only
+about *whether to disparar* the analysis, not about silently persisting.
+
+After all selected analyses complete (or are declined), proceed to Phase 6.
+
+### 5.5.4 Hard rules
+
+1. **Never auto-disparar in batch without the user's explicit confirmation.**
+   Even with all-auto-eligible default selected, the question must be asked.
+2. **Group meetings are always skipped** — Granola "Me/Them" attribution
+   collapses in groups. The user can run `/bedrock:analyze-call gdoc <url>`
+   manually with a Meet transcript if needed.
+3. **Privacy continues:** behavioral analysis output goes to the person's Log
+   with `[análise]` prefix and `<!-- private: coaching -->` marker. The
+   `/bedrock:analyze-call` skill enforces this; granola only invokes.
+4. **Cost awareness:** if more than 5 meetings are eligible at once, warn the
+   user about token cost before proceeding ("Isso vai ler {N} transcripts
+   completos. Confirmar?").
+
+---
+
+## Phase 6 — Register Processed IDs
+
+After successfully processing each meeting, append its ID to the registry —
+**but only if not already there** (defensive against re-processing scenarios):
+
+```bash
+id="<meeting_uuid>"
+grep -qF "$id" "$REGISTRY" || echo "$id" >> "$REGISTRY"
+```
+
+One ID per line. Append only — never remove or rewrite the file. The
+`grep -qF || echo` pattern keeps the file deduplicated without rewriting it.
 
 ---
 
@@ -272,6 +366,10 @@ Distribuição:
 - N discussions criadas
 - N decisões → Teams
 - N updates → Projetos
+
+Análise comportamental:
+- N reunião(ões) elegível(is) → analisada(s) via /bedrock:analyze-call
+- N pulada(s) (grupo / peer / sem transcript)
 ```
 
 ---
@@ -285,3 +383,8 @@ Distribuição:
 5. **Graceful degradation** — if Granola MCP is unavailable, inform the user and stop. Never error out.
 6. **Language** — use the vault's configured language for all output and entity content.
 7. **Discussion slug** — derive from meeting title: lowercase, no accents, spaces→hyphens, max 50 chars.
+8. **Behavioral analysis hook (Phase 5.5)** — after ingestion, offer to run
+   `/bedrock:analyze-call` on eligible 1:1s (direct-report / indirect-report
+   default-on; peer default-off). Group meetings are always skipped
+   (Granola speaker attribution collapses). Always ask before dispatching;
+   never silently auto-disparar.


### PR DESCRIPTION
## Contexto

Durante uma sessão de desenvolvimento, ficou claro que **3 contribuições** desenvolvidas pelo mantenedor estavam só no cache do plugin instalado (\`~/.claude/plugins/cache/claude-bedrock/.../skills/\`), **não no \`main\`** do GitHub.

Isso aconteceu porque mudanças foram feitas direto no cache durante uso (skill editada ao invés de editada no source clonado). Próximo \`claude plugin update bedrock\` puxaria a versão do main remoto e **sobrescreveria essas contribuições**, perdendo trabalho real.

Este PR traz tudo pro main, eliminando o risco.

## Mudanças

### 🆕 \`skills/analyze-call/SKILL.md\` (novo, 470 linhas)

Skill \`/bedrock:analyze-call\` — **Behavioral analysis** de uma call específica:
- Extrai turn-taking, interruptions, % de fala por participante
- Padrões linguísticos por speaker
- Sinais observáveis de competência (mapeáveis pra Reforge Product Competency Model)
- Follow-ups sugeridos pra próximo 1:1
- Output curado vai pro \`## Log\` da pessoa — **nunca** transcrição literal

Modo default é interativo (sempre confirma antes de persistir). Skill canônica de coaching mencionada em \`mgmt/CLAUDE.md\`.

### 🆕 \`skills/catch-up/SKILL.md\` (novo, 377 linhas)

Skill \`/bedrock:catch-up\` — **Orquestrador \"processar o dia\"**:
- Descobre items não-processados em 3 fontes: daily fleeting note + Drive transcripts (Gemini Meet) + Granola meetings (via MCP)
- Dedupe Drive vs Granola pra mesma reunião (Drive vence)
- Rota tudo via \`/bedrock:preserve\` numa run coordenada

Single source of truth pra \"processei tudo do dia?\". Citada em referências internas do mantenedor.

### ✏️ \`skills/granola/SKILL.md\` (modificado, +118/-15)

Refatoração da **Phase 1** — \"Load Processed IDs\" → \"Ensure Registry Exists\":

**Antes** (no main atual):
\`\`\`markdown
Read the registry of already-processed meeting IDs:
\`cat <VAULT_PATH>/granola-processados.md\`
\`\`\`

**Depois** (versão do cache):
\`\`\`markdown
Make sure the processed-IDs registry file exists. **Do NOT load its contents
into context.** Membership checks happen later via \`grep\` (Phase 2.2).
\`\`\`

Reasoning citado direto na skill:
> *\"the file grows unbounded over time (potentially thousands of IDs after a year). Loading it into the LLM context inflates token usage with no benefit, and slicing the read with \`head\`/\`tail\` risks missing IDs that happen to land outside the slice (this caused a bug on 2026-05-05). \`grep -qF\` is O(file size) on disk but O(1) on context.\"*

Codifica a prática **\"Membership via shell grep, não LLM context\"** — uma das lições internas do mantenedor.

## Garantia de não-regressão

- Backup do cache salvo em \`/tmp/bedrock-cache-backup-20260520-225733/\` antes do PR como salvaguarda (independente deste merge).
- Arquivos copiados **exatamente** como estavam no cache (nenhuma edição de minha parte além de \`cp\`).
- Esta PR não toca em nenhum outro arquivo do plugin além desses 3.

## Como aconteceu

Durante o desenvolvimento desses meses, mudanças foram feitas direto no cache do plugin via Edit/Write quando o plugin era usado em sessão. Foram trabalho real e útil, mas o ciclo de PR não foi fechado.

## Próximo plugin update fica seguro

Após merge:
\`\`\`bash
claude plugin update bedrock
\`\`\`
…vai trazer essas 3 contribuições pra qualquer setup limpo (em vez de remover do mantenedor).

🤖 Co-authored via auditoria de divergência cache vs source