### PR TITLE
chore: sync upstream basics (LICENSE + preserve bug fix + infra)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,14 +11,24 @@
       "name": "bedrock",
       "source": "./",
       "description": "Second Brain automation for Obsidian vaults — entity management, ingestion, compression, and sync via Claude Code skills",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "author": {
-        "name": "Iury Krieger"
+        "name": "Iury Krieger",
+        "url": "https://github.com/iurykrieger"
       },
-      "homepage": "https://iurykrieger.github.io/claude-bedrock",
+      "homepage": "https://claude-bedrock.vercel.app",
       "repository": "https://github.com/iurykrieger/claude-bedrock",
       "license": "MIT",
-      "keywords": ["obsidian", "second-brain", "knowledge-base", "zettelkasten", "vault"],
+      "keywords": [
+        "obsidian",
+        "second-brain",
+        "knowledge-base",
+        "zettelkasten",
+        "vault",
+        "knowledge-management",
+        "knowledge-graph",
+        "note-taking"
+      ],
       "category": "knowledge-management"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,17 +1,23 @@
 {
   "name": "bedrock",
   "description": "Second Brain automation for Obsidian vaults — entity management, ingestion, compression, and sync via Claude Code skills",
-  "version": "1.2.0",
+  "version": "1.6.0",
   "author": {
-    "name": "Iury Krieger"
+    "name": "Iury Krieger",
+    "url": "https://github.com/iurykrieger"
   },
+  "homepage": "https://claude-bedrock.vercel.app",
   "repository": "https://github.com/iurykrieger/claude-bedrock",
   "license": "MIT",
+  "category": "knowledge-management",
   "keywords": [
     "obsidian",
     "second-brain",
     "knowledge-base",
     "zettelkasten",
-    "vault"
+    "vault",
+    "knowledge-management",
+    "knowledge-graph",
+    "note-taking"
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,9 @@ jobs:
 
       - name: Determine bump type
         id: bump
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
           if echo "$COMMIT_MSG" | grep -qiE "^feat"; then
             echo "type=minor" >> "$GITHUB_OUTPUT"
           else

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 .vercel
+
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+
+docs/superpowers/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Iury Krieger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/preserve/SKILL.md
+++ b/skills/preserve/SKILL.md
@@ -241,6 +241,7 @@ If the Python block exits non-zero, abort without running the `mv` — the vault
 
 **Step 4 — Append `obsidian/*.md` files.** For each markdown file in `<graphify_output_path>/obsidian/`:
 
+- Skip any file whose `source_file` frontmatter value starts with `/tmp/` — these are ephemeral visualization files produced by `/bedrock:teach` and must not accumulate in the vault.
 - If the corresponding file exists in `<VAULT_PATH>/graphify-out/obsidian/`: append the incoming content to the existing file, separated by `\n\n---\n\n`. Existing content is preserved verbatim.
 - If it does not exist: copy the file into `<VAULT_PATH>/graphify-out/obsidian/`.
 
@@ -248,6 +249,8 @@ If the Python block exits non-zero, abort without running the `mv` — the vault
 mkdir -p "<VAULT_PATH>/graphify-out/obsidian"
 for src in "<graphify_output_path>/obsidian/"*.md; do
   [ -e "$src" ] || continue
+  SRC_FILE=$(awk -F'"' '/^source_file:/{print $2; exit}' "$src")
+  case "$SRC_FILE" in /tmp/*) continue ;; esac
   dest="<VAULT_PATH>/graphify-out/obsidian/$(basename "$src")"
   if [ -e "$dest" ]; then
     printf '\n\n---\n\n' >> "$dest"


### PR DESCRIPTION
Primeiro de 3 PRs de sync com upstream iurykrieger/claude-bedrock. Inclui LICENSE (MIT), .gitignore, .github workflow fix, .claude-plugin metadata enhancements + version bump 1.6.0, skills/preserve/SKILL.md bug fix (a8667a9, skip de /tmp/ source_file no Phase 0.2 Step 4). NÃO incluído: .vibeflow/, features substantivas (PR-B), rename teach→learn (PR-C).