### PR TITLE
chore: sync upstream — rename teach→learn + features substantivas (PR-B+C consolidado)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ The vault organizes knowledge into 8 entity types, each in its own directory:
 
 Each entity type has a `_template.md` defining the required frontmatter and structure. **Always follow the template when creating new entities.**
 
-Entity semantic definitions live in the plugin's `entities/` directory — used by `/bedrock:teach` and `/bedrock:preserve` to classify content.
+Entity semantic definitions live in the plugin's `entities/` directory — used by `/bedrock:learn` and `/bedrock:preserve` to classify content.
 
 ---
 
@@ -107,7 +107,7 @@ These are the Claude Code skills provided by the Bedrock plugin:
 | Skill | Purpose |
 |---|---|
 | `/bedrock:ask` | Orchestrated vault reader — decomposes questions, searches graph and vault, cross-references entities |
-| `/bedrock:teach` | Ingest external sources (Confluence, Google Docs, GitHub repositories, remote URLs, and any file format supported by docling — DOCX, PPTX, XLSX, PDF, HTML, EPUB, images, and more) — extracts entities — delegates to `/bedrock:preserve` |
+| `/bedrock:learn` | Ingest external sources (Confluence, Google Docs, GitHub repositories, remote URLs, and any file format supported by docling — DOCX, PPTX, XLSX, PDF, HTML, EPUB, images, and more) — extracts entities — delegates to `/bedrock:preserve` |
 | `/bedrock:preserve` | Single write point — entity detection, matching, create/update, bidirectional links, git commit |
 | `/bedrock:compress` | Vault alignment engine — fixes broken backlinks, concept fragmentation, entity miscategorization, duplicated entities, misnamed entities. Supports `--mode cron` for scheduled execution |
 | `/bedrock:healthcheck` | Read-only vault health diagnostic — checks graphify-out integrity, setup, orphan entities, dangling content, old content (>15 days). Safe to run at any frequency |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The setup creates all entity directories, copies templates, generates a vault-le
 |---|---|
 | `/bedrock:setup` | Interactive vault initialization and configuration |
 | `/bedrock:ask` | Orchestrated vault reader — decomposes questions, searches graph and vault, cross-references entities |
-| `/bedrock:teach` | Ingest external sources — extract and create entities |
+| `/bedrock:learn` | Ingest external sources — extract and create entities |
 | `/bedrock:preserve` | Single write point — detect, match, create/update entities with bidirectional links |
 | `/bedrock:compress` | Deduplication and vault health — broken links, orphans, stale content |
 | `/bedrock:sync` | Re-sync entities with external sources |
@@ -98,7 +98,7 @@ Bedrock turns your vault into a living knowledge graph by combining **8 skills**
 
 ### Day-to-day loops
 
-- **Capture knowledge from a source** — paste a Confluence page, Google Doc, GitHub repo, remote URL, or any local file (DOCX, PPTX, XLSX, PDF, HTML, EPUB, images, and any other docling-supported format) into `/bedrock:teach`. Bedrock extracts entities and writes them to the vault with bidirectional links.
+- **Capture knowledge from a source** — paste a Confluence page, Google Doc, GitHub repo, remote URL, or any local file (DOCX, PPTX, XLSX, PDF, HTML, EPUB, images, and any other docling-supported format) into `/bedrock:learn`. Bedrock extracts entities and writes them to the vault with bidirectional links.
 - **Ask the vault questions** — use `/bedrock:ask` for anything like *"who owns the billing API?"* or *"what's the status of project X?"*. It searches the graph, follows wikilinks, and answers with citations.
 - **Keep sources fresh** — run `/bedrock:sync` to re-pull external sources, or `/bedrock:sync --github` / `--people` to surface recent activity and contributors.
 - **Clean up drift** — run `/bedrock:compress` to fix broken backlinks, merge duplicates, and consolidate fragmented concepts. Run `/bedrock:healthcheck` for a read-only report.
@@ -112,12 +112,12 @@ Every entity has YAML frontmatter (type, status, domain, sources), hierarchical 
 
 | Tool | Purpose | Required? |
 |---|---|---|
-| [graphify](https://github.com/iurykrieger/graphify) | Semantic code extraction and knowledge-graph pipeline used by `/bedrock:teach` and `/bedrock:sync` | Yes |
-| [docling](https://github.com/docling-project/docling) | Universal file → markdown converter used by `/bedrock:teach` to ingest DOCX, PPTX, XLSX, PDF, HTML, EPUB, images, and other non-markdown formats | Yes |
+| [graphify](https://github.com/iurykrieger/graphify) | Semantic code extraction and knowledge-graph pipeline used by `/bedrock:learn` and `/bedrock:sync` | Yes |
+| [docling](https://github.com/docling-project/docling) | Universal file → markdown converter used by `/bedrock:learn` to ingest DOCX, PPTX, XLSX, PDF, HTML, EPUB, images, and other non-markdown formats | Yes |
 
-Both `graphify` and `docling` are auto-installed by `/bedrock:setup` (and lazily by `/bedrock:teach` on first use if missing). You can also install them manually via `pipx install graphify` / `pipx install docling`.
+Both `graphify` and `docling` are auto-installed by `/bedrock:setup` (and lazily by `/bedrock:learn` on first use if missing). You can also install them manually via `pipx install graphify` / `pipx install docling`.
 
-Confluence and Google Docs ingestion are built into the plugin as internal skills (`/bedrock:confluence-to-markdown`, `/bedrock:gdoc-to-markdown`) invoked by `/bedrock:teach` and `/bedrock:sync` — no external installation required.
+Confluence and Google Docs ingestion are built into the plugin as internal skills (`/bedrock:confluence-to-markdown`, `/bedrock:gdoc-to-markdown`) invoked by `/bedrock:learn` and `/bedrock:sync` — no external installation required.
 
 ## Configuration
 

--- a/entities/fleeting.md
+++ b/entities/fleeting.md
@@ -25,7 +25,7 @@ Fleeting notes **do not need** to be complete — that is the point. They exist 
 
 ## When to create
 
-- Content ingested by `/teach` contains ideas, mentions, or fragments that do not meet the completeness criteria of any permanent or bridge type
+- Content ingested by `/learn` contains ideas, mentions, or fragments that do not meet the completeness criteria of any permanent or bridge type
 - The content mentions something potentially useful but without enough data to create an entity (e.g., "someone mentioned a new tokenization service" — no name, repo, or team)
 - The content captures a hypothesis, suggestion, or draft idea that needs refinement
 - `/preserve` receives content that does not pass the completeness criteria of any type
@@ -59,7 +59,7 @@ The fleeting note accumulates enough information to be self-contained:
 ### 2. Corroboration
 
 The information in the fleeting note is confirmed or supplemented by an existing permanent note:
-- A new ingestion via `/teach` brings data that validates or expands the fleeting
+- A new ingestion via `/learn` brings data that validates or expands the fleeting
 - An existing permanent is updated with information that confirms the fleeting's content
 - Two or more fleeting notes about the same subject can be consolidated into a permanent note
 
@@ -72,7 +72,7 @@ The information in the fleeting note is confirmed or supplemented by an existing
 
 ## Promotion Pipeline
 
-1. **Detection** — `/preserve`, `/teach`, or `/bedrock` identifies that a promotion criterion has been met
+1. **Detection** — `/preserve`, `/learn`, or `/bedrock` identifies that a promotion criterion has been met
 2. **Signaling** — The skill signals with a callout: `> [!info] Suggested promotion: this note can be promoted to <type>`
 3. **Promotion** — `/preserve` is invoked to create the destination entity, migrating the relevant content
 4. **Update** — The fleeting note receives `status: promoted` and `promoted_to: [[destination-note]]`

--- a/entities/sources-field.md
+++ b/entities/sources-field.md
@@ -34,7 +34,7 @@ sources:
 
 ## When to populate
 
-- An external source was ingested via `/teach` and the content created or updated this entity
+- An external source was ingested via `/learn` and the content created or updated this entity
 - `/sync` re-synchronized a source and updated `synced_at`
 - The user wants to manually record the provenance of an entity
 

--- a/hooks/error_reporter.py
+++ b/hooks/error_reporter.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""Bedrock error reporter hook — auto-creates GitHub issues for framework errors.
+
+Stop hook entrypoint. Reads transcript via stdin JSON, scans the last turn
+for bedrock framework errors (technical + logical), opens deduplicated issues
+on iurykrieger/claude-bedrock via the gh CLI.
+
+Never raises, always exits 0. Failures log to ~/.claude-bedrock-cache/error-reporter.log.
+"""
+import hashlib
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+# Keep window small for performance: only the most recent N lines matter,
+# since hook fires per turn and older lines are from prior turns.
+_TRANSCRIPT_TAIL_LINES = 200
+
+_BEDROCK_INVOCATION_RE = re.compile(r"/bedrock:(\w+)")
+
+_TRACEBACK_RE = re.compile(r"Traceback \(most recent call last\):", re.MULTILINE)
+_LAST_FRAME_RE = re.compile(r'File "([^"]+)", line (\d+), in (\w+)\n((?!\s*File ")[^\n]*\n)?([A-Z][\w\.]+(?:Error|Exception):.*)', re.MULTILINE)
+
+# Regex catalog. ID -> compiled regex. Keep small to avoid false positives.
+_LOGICAL_ERROR_CATALOG = {
+    "graphify_invalid": re.compile(r"graphify.{0,40}(returned|gave|produced).{0,20}invalid", re.IGNORECASE),
+    "vault_corrupt": re.compile(r"vault\.json.{0,30}corrupt", re.IGNORECASE),
+    "skill_failure": re.compile(r"bedrock\s+\w+\s+(skill\s+)?failed", re.IGNORECASE),
+    "entity_unwritable": re.compile(r"failed\s+to\s+(write|persist)\s+entity", re.IGNORECASE),
+    "sync_unauthorized": re.compile(r"(sync.{0,30}unauthorized|auth(?:entication)?\s+failed.{0,30}sync)", re.IGNORECASE),
+}
+
+# Redaction regexes — order matters in redact(). See function docstring.
+_HOME_PATH_RE = re.compile(r"(?:/Users/[^/\s]+|/home/[^/\s]+|/root)(?:/[^/\s]+)*?(?=/\.claude/plugins/[^/\s]+/[^/\s]+)")
+_GENERIC_HOME_PATH_RE = re.compile(r"(?:/Users/[^/\s]+|/home/[^/\s]+|/root)")
+_PLUGIN_PREFIX_RE = re.compile(r"\.claude/plugins/[^/\s]+/[^/\s]+/")
+_UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE)
+_URL_RE = re.compile(r"https?://[^\s'\"<>)]+", re.IGNORECASE)
+_ISO_TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+\-]\d{2}:?\d{2})?")
+_VAULT_ENTITY_FILE_RE = re.compile(r"\b(?:people|teams|actors|concepts|topics|discussions|projects|fleeting)/[\w-]+\.md\b")
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_CC_LIKE_RE = re.compile(r"\b\d[\d -]{11,17}\d\b")
+_API_KEY_RE = re.compile(r"\b(?:sk_(?:live|test)|ghp|ghs|gho|ghu|ghr|xox[abps]|AKIA|ASIA|GITHUB_TOKEN)[\w_-]{10,}\b", re.IGNORECASE)
+_BARE_WIKILINK_RE = re.compile(r"\[\[[\w/-]+\]\]")
+
+
+def _read_transcript_tail(transcript_path: Path) -> str:
+    """Read up to the last _TRANSCRIPT_TAIL_LINES of a JSONL transcript.
+
+    Returns empty string if the file does not exist or is unreadable.
+    """
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except (FileNotFoundError, OSError):
+        return ""
+    return "".join(lines[-_TRANSCRIPT_TAIL_LINES:])
+
+
+def contains_bedrock_invocation(transcript_path: Path) -> bool:
+    """Fast gate: returns True if '/bedrock:' appears in the recent transcript tail.
+
+    Intentionally a substring check, not JSON parsing — optimized for the 99% case
+    where the answer is no. False positives (e.g., the substring quoted in an
+    assistant message) only cost an extra slow-path traversal in the next stage;
+    false negatives would mean lost error reports, which is the worse failure mode.
+    """
+    tail = _read_transcript_tail(Path(transcript_path))
+    return "/bedrock:" in tail
+
+
+def is_reporting_enabled(start_dir: Path) -> bool:
+    """Walk up from start_dir looking for .bedrock/config.json.
+
+    Returns True (default) if no config found, config malformed, or field missing.
+    Returns False only if config explicitly sets error_reporting to the JSON `false`
+    boolean — null, "false" strings, 0, etc. all default-on. Opt-out must be
+    well-formed and intentional.
+    """
+    current = Path(start_dir).resolve()
+    for candidate in [current, *current.parents]:
+        cfg_path = candidate / ".bedrock" / "config.json"
+        if cfg_path.is_file():
+            try:
+                with open(cfg_path, "r", encoding="utf-8") as f:
+                    cfg = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                return True  # default-on if config unreadable
+            val = cfg.get("error_reporting", True)
+            return val if isinstance(val, bool) else True
+    return True
+
+
+def _iter_transcript_lines(transcript_path: Path) -> Iterable[dict]:
+    """Yield parsed JSON objects from each non-empty JSONL line. Skips malformed lines."""
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+    except (FileNotFoundError, OSError):
+        return
+
+
+def _iter_last_turn_lines(transcript_path: Path) -> list[dict]:
+    """Return parsed JSON entries from the last turn.
+
+    A turn boundary is defined by a role=user entry containing a type=text content
+    block (i.e., a user-typed message, not a tool_result). Returns the last such
+    entry and everything after it. If no boundary is found, returns all entries.
+    """
+    entries = list(_iter_transcript_lines(transcript_path))
+    if not entries:
+        return []
+
+    # Walk backwards to find the last user-typed message
+    last_user_text_idx = None
+    for idx in range(len(entries) - 1, -1, -1):
+        entry = entries[idx]
+        if entry.get("role") != "user":
+            continue
+        for block in entry.get("message", {}).get("content", []) or []:
+            if isinstance(block, dict) and block.get("type") == "text":
+                last_user_text_idx = idx
+                break
+        if last_user_text_idx is not None:
+            break
+
+    if last_user_text_idx is None:
+        return entries  # fallback: scan everything
+    return entries[last_user_text_idx:]
+
+
+def extract_skill_invocation(transcript_path: Path) -> str | None:
+    """Return the most recent /bedrock:<skill> reference, e.g. 'bedrock:teach'."""
+    last = None
+    for entry in _iter_last_turn_lines(transcript_path):
+        for block in entry.get("message", {}).get("content", []) or []:
+            text = block.get("text") if isinstance(block, dict) else None
+            if not text:
+                continue
+            for match in _BEDROCK_INVOCATION_RE.finditer(text):
+                last = f"bedrock:{match.group(1)}"
+    return last
+
+
+def extract_tool_results(transcript_path: Path) -> list[dict]:
+    """Return all tool_result blocks from the transcript with their is_error flag and content."""
+    results = []
+    for entry in _iter_last_turn_lines(transcript_path):
+        for block in entry.get("message", {}).get("content", []) or []:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "tool_result":
+                content = block.get("content", "")
+                if isinstance(content, list):
+                    content = "".join(c.get("text", "") for c in content if isinstance(c, dict))
+                results.append({
+                    "tool_use_id": block.get("tool_use_id", ""),
+                    "is_error": bool(block.get("is_error", False)),
+                    "content": str(content),
+                })
+    return results
+
+
+def extract_assistant_text(transcript_path: Path) -> str:
+    """Concatenate all text blocks from assistant messages."""
+    parts = []
+    for entry in _iter_last_turn_lines(transcript_path):
+        if entry.get("role") != "assistant":
+            continue
+        for block in entry.get("message", {}).get("content", []) or []:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+    return "\n".join(parts)
+
+
+def detect_technical_errors(tool_results: list[dict]) -> list[dict]:
+    """Inspect tool results and surface technical errors.
+
+    Returns a list of dicts with keys: error_type, signature, raw.
+    error_type is one of: 'python_traceback', 'bash_failure'.
+    """
+    errors = []
+    for r in tool_results:
+        content = r.get("content", "") or ""
+        is_err = r.get("is_error", False)
+
+        if _TRACEBACK_RE.search(content):
+            sig = _extract_traceback_signature(content)
+            errors.append({
+                "error_type": "python_traceback",
+                "signature": sig,
+                "raw": content[:1024],
+            })
+        elif is_err:
+            sig = content.strip().splitlines()[0] if content.strip() else "unknown bash failure"
+            errors.append({
+                "error_type": "bash_failure",
+                "signature": sig[:200],
+                "raw": content[:1024],
+            })
+    return errors
+
+
+def _extract_traceback_signature(content: str) -> str:
+    """Pull the deepest frame + exception line from a Python traceback."""
+    matches = list(_LAST_FRAME_RE.finditer(content))
+    if matches:
+        m = matches[-1]
+        return f'File "{m.group(1)}", line {m.group(2)} | {m.group(5)}'
+    return "Traceback (no frames extracted)"
+
+
+def detect_logical_errors(assistant_text: str) -> list[dict]:
+    """Scan the assistant's narrative for known framework-failure phrasings.
+
+    Each matched pattern produces one error entry. Multiple distinct patterns produce
+    multiple errors; multiple matches of the same pattern collapse to one.
+    """
+    errors = []
+    for pattern_id, regex in _LOGICAL_ERROR_CATALOG.items():
+        match = regex.search(assistant_text)
+        if not match:
+            continue
+        # Signature stays generic to avoid leaking user content; raw keeps a short snippet
+        # for context but will be aggressively redacted by _build_issue_body.
+        start = max(0, match.start() - 20)
+        end = min(len(assistant_text), match.end() + 60)
+        snippet = assistant_text[start:end].replace("\n", " ").strip()
+        errors.append({
+            "error_type": f"logical_{pattern_id}",
+            "signature": f"matched pattern: {pattern_id}",
+            "raw": snippet[:512],
+        })
+    return errors
+
+
+def redact(text: str) -> str:
+    """Strip user-identifying data: paths, URLs, UUIDs, timestamps, entity filenames.
+
+    Order matters: home-path-with-plugin-lookahead first (so the plugin prefix can
+    then be collapsed), then bare home paths, then everything else.
+
+    Replacement uses '...' (no trailing slash) because the slash that follows
+    the home prefix is preserved in the original string. This avoids producing
+    '...//' artifacts.
+    """
+    if not text:
+        return text
+
+    text = _HOME_PATH_RE.sub("...", text)
+    text = _PLUGIN_PREFIX_RE.sub("", text)
+    text = _GENERIC_HOME_PATH_RE.sub("...", text)
+    text = _URL_RE.sub("<url-redacted>", text)
+    text = _EMAIL_RE.sub("<email-redacted>", text)
+    text = _API_KEY_RE.sub("<key-redacted>", text)
+    text = _UUID_RE.sub("<id-redacted>", text)
+    text = _ISO_TIMESTAMP_RE.sub("<ts-redacted>", text)
+    text = _CC_LIKE_RE.sub("<digits-redacted>", text)
+    text = _VAULT_ENTITY_FILE_RE.sub(lambda m: f"{m.group(0).split('/')[0]}/<entity>.md", text)
+    text = _BARE_WIKILINK_RE.sub("[[<entity>]]", text)
+    return text
+
+
+def error_hash(skill: str, error_type: str, signature: str) -> str:
+    """Deterministic 8-char hash over normalized error identity."""
+    normalized = redact(signature)
+    raw = f"{skill}|{error_type}|{normalized}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
+
+
+def dedupe_by_hash(errors: list[dict], skill: str) -> list[dict]:
+    """Collapse duplicate errors by hash. Adds 'hash' key to each surviving entry."""
+    seen = {}
+    for err in errors:
+        h = error_hash(skill, err["error_type"], err["signature"])
+        if h in seen:
+            continue
+        err = {**err, "hash": h}
+        seen[h] = err
+    return list(seen.values())
+
+
+_REPO = "iurykrieger/claude-bedrock"
+_CACHE_TTL_SECONDS = 300
+_DEFAULT_CACHE_DIR = Path.home() / ".claude-bedrock-cache"
+
+
+def _run_gh(args: list[str], timeout: int = 5) -> tuple[int, str, str]:
+    """Run gh CLI. Returns (exit_code, stdout, stderr). Never raises on subprocess errors."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return 127, "", "gh not available or timed out"
+
+
+def find_existing_issue(error_hash: str, cache_dir: Path | None = None) -> dict | None:
+    """Look up an existing auto-reported issue by hash, with file-based 5-min cache.
+
+    Returns None if no matching issue, or if gh is unavailable.
+    """
+    cache_dir = cache_dir or _DEFAULT_CACHE_DIR
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = cache_dir / f"issues-{error_hash}.json"
+
+    if cache_path.is_file():
+        age = time.time() - cache_path.stat().st_mtime
+        if age < _CACHE_TTL_SECONDS:
+            try:
+                payload = json.loads(cache_path.read_text())
+                return payload.get("issue")
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    code, stdout, _ = _run_gh([
+        "issue", "list",
+        "--repo", _REPO,
+        "--label", "auto-reported",
+        "--search", f"[bedrock][{error_hash}] in:title",
+        "--state", "all",
+        "--json", "number,state",
+        "--limit", "1",
+    ])
+    if code != 0:
+        return None
+    try:
+        issues = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    issue = issues[0] if issues else None
+    try:
+        cache_path.write_text(json.dumps({"issue": issue}))
+    except OSError:
+        pass
+    return issue
+
+
+def _plugin_version() -> str:
+    plugin_json = Path(__file__).resolve().parent.parent / ".claude-plugin" / "plugin.json"
+    try:
+        with open(plugin_json, "r", encoding="utf-8") as f:
+            return json.load(f).get("version", "unknown")
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return "unknown"
+
+
+def _build_issue_title(error: dict, skill: str) -> str:
+    short_skill = skill.replace("bedrock:", "")
+    sig = redact(error["signature"])
+    if len(sig) > 80:
+        sig = sig[:77] + "..."
+    return f"[bedrock][{error['hash']}] {short_skill}: {sig}"
+
+
+def _build_issue_body(error: dict, skill: str) -> str:
+    redacted_sig = redact(error["signature"])
+    redacted_raw = redact(error.get("raw", ""))
+    redacted_raw = " ".join(redacted_raw.split())[:256]  # collapse whitespace, hard cap
+    return (
+        "## Auto-reported error\n\n"
+        f"**Skill:** `{skill}`\n"
+        f"**Error type:** `{error['error_type']}`\n"
+        f"**Plugin version:** `{_plugin_version()}`\n"
+        f"**OS:** `{platform.system().lower()} {platform.release()}`\n"
+        f"**Hash:** `{error['hash']}`\n\n"
+        "### Error signature\n"
+        "```\n"
+        f"{redacted_sig}\n"
+        "```\n\n"
+        "### Raw context (redacted)\n"
+        "```\n"
+        f"{redacted_raw}\n"
+        "```\n\n"
+        f"### First seen\n"
+        f"{datetime.now(timezone.utc).isoformat()}\n\n"
+        "---\n"
+        "<sub>Auto-reported by Bedrock error hook. To opt out, set "
+        "`error_reporting: false` in `.bedrock/config.json`.</sub>\n"
+    )
+
+
+def _build_comment_body(prefix: str = "") -> str:
+    return (
+        f"{prefix}Reoccurred at {datetime.now(timezone.utc).isoformat()}. "
+        f"Plugin v{_plugin_version()}, {platform.system().lower()} {platform.release()}.\n"
+    )
+
+
+def handle_error(error: dict, skill: str) -> None:
+    """Create / comment / reopen the GitHub issue for this error.
+
+    Never raises. Failures are silent (caller already exits 0).
+    """
+    existing = find_existing_issue(error["hash"])
+
+    if existing is None:
+        labels = ["auto-reported", "auto-bug", skill]
+        cmd = [
+            "issue", "create",
+            "--repo", _REPO,
+            "--title", _build_issue_title(error, skill),
+            "--body", _build_issue_body(error, skill),
+        ]
+        for label in labels:
+            cmd.extend(["--label", label])
+        _run_gh(cmd, timeout=10)
+        return
+
+    issue_num = str(existing["number"])
+    if existing.get("state") == "closed":
+        _run_gh(["issue", "reopen", "--repo", _REPO, issue_num], timeout=5)
+        comment_body = _build_comment_body(prefix="**Regression:** ")
+    else:
+        comment_body = _build_comment_body()
+
+    _run_gh([
+        "issue", "comment",
+        "--repo", _REPO,
+        issue_num,
+        "--body", comment_body,
+    ], timeout=10)
+
+
+def _cache_dir() -> Path:
+    """Indirection for tests. Returns the cache directory, creating it if needed."""
+    cache_dir = _DEFAULT_CACHE_DIR
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+
+def _log_local(error: dict, skill: str, reason: str) -> None:
+    log_path = _cache_dir() / "error-reporter.log"
+    line = (
+        f"{datetime.now(timezone.utc).isoformat()} "
+        f"hash={error['hash']} skill={skill} type={error['error_type']} reason={reason}\n"
+    )
+    try:
+        if log_path.is_file() and log_path.stat().st_size > 1_048_576:
+            log_path.rename(log_path.with_suffix(".log.1"))
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError:
+        pass
+
+
+def handle_error_with_fallback(error: dict, skill: str, session_id: str) -> None:
+    """Wraps handle_error with auth-failure detection and per-session circuit breaker."""
+    flag_path = _cache_dir() / f".auth-failed-{session_id}"
+    if flag_path.exists():
+        _log_local(error, skill, "auth-flag-set-skip")
+        return
+
+    code, _, _ = _run_gh(["auth", "status"], timeout=3)
+    if code != 0:
+        try:
+            flag_path.touch()
+        except OSError:
+            pass
+        _log_local(error, skill, "auth-failed")
+        return
+
+    try:
+        handle_error(error, skill)
+    except Exception as exc:  # pragma: no cover — defensive
+        _log_local(error, skill, f"unexpected:{type(exc).__name__}")
+
+
+def main() -> int:
+    try:
+        hook_input = json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        return 0
+
+    transcript_path = hook_input.get("transcript_path")
+    session_id = hook_input.get("session_id", "unknown")
+    if not transcript_path:
+        return 0
+
+    transcript = Path(transcript_path)
+    if not contains_bedrock_invocation(transcript):
+        return 0
+
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    if not is_reporting_enabled(project_dir):
+        return 0
+
+    skill = extract_skill_invocation(transcript) or "bedrock:unknown"
+    tool_results = extract_tool_results(transcript)
+    assistant_text = extract_assistant_text(transcript)
+
+    errors = detect_technical_errors(tool_results) + detect_logical_errors(assistant_text)
+    if not errors:
+        return 0
+
+    for err in dedupe_by_hash(errors, skill=skill):
+        try:
+            handle_error_with_fallback(err, skill, session_id)
+        except Exception as exc:  # pragma: no cover
+            _log_local(err, skill, f"top-level:{type(exc).__name__}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Auto-report bedrock framework errors as GitHub issues",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/error_reporter.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/tests/fixtures/transcript_bedrock_clean.jsonl
+++ b/hooks/tests/fixtures/transcript_bedrock_clean.jsonl
@@ -1,0 +1,2 @@
+{"role":"user","message":{"content":[{"type":"text","text":"/bedrock:ask what is the auth flow"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"The auth flow uses OAuth."}]}}

--- a/hooks/tests/fixtures/transcript_bedrock_logical_error.jsonl
+++ b/hooks/tests/fixtures/transcript_bedrock_logical_error.jsonl
@@ -1,0 +1,2 @@
+{"role":"user","message":{"content":[{"type":"text","text":"/bedrock:teach https://example.com/x"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"I tried to run /bedrock:teach but graphify returned an invalid structure. Failed to persist entity 'foo-service'."}]}}

--- a/hooks/tests/fixtures/transcript_bedrock_old_turn.jsonl
+++ b/hooks/tests/fixtures/transcript_bedrock_old_turn.jsonl
@@ -1,0 +1,5 @@
+{"role":"user","message":{"content":[{"type":"text","text":"/bedrock:teach old-doc"}]}}
+{"role":"user","message":{"content":[{"type":"tool_result","tool_use_id":"old1","is_error":true,"content":"Traceback (most recent call last):\n  File \"old.py\", line 1, in <module>\nValueError: stale error from turn 1"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"Old turn done."}]}}
+{"role":"user","message":{"content":[{"type":"text","text":"List my files"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"Here you go."}]}}

--- a/hooks/tests/fixtures/transcript_bedrock_traceback.jsonl
+++ b/hooks/tests/fixtures/transcript_bedrock_traceback.jsonl
@@ -1,0 +1,4 @@
+{"role":"user","message":{"content":[{"type":"text","text":"/bedrock:teach https://example.com/doc"}]}}
+{"role":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"python3 /Users/foo/.claude/plugins/.../skills/teach/scripts/extract.py /tmp/in.pdf"}}]}}
+{"role":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","is_error":true,"content":"Traceback (most recent call last):\n  File \"/Users/foo/.claude/plugins/.../skills/teach/scripts/extract.py\", line 42, in <module>\n    import docling\nModuleNotFoundError: No module named 'docling'"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"I tried to run the teach skill but docling is missing on this machine."}]}}

--- a/hooks/tests/fixtures/transcript_no_bedrock.jsonl
+++ b/hooks/tests/fixtures/transcript_no_bedrock.jsonl
@@ -1,0 +1,2 @@
+{"role":"user","message":{"content":[{"type":"text","text":"List files"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"Here are the files."}]}}

--- a/hooks/tests/test_config.py
+++ b/hooks/tests/test_config.py
@@ -1,0 +1,71 @@
+import json
+import unittest
+from pathlib import Path
+import sys
+import tempfile
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOKS_DIR))
+
+import error_reporter as er
+
+
+class TestOptOut(unittest.TestCase):
+    def test_reporting_enabled_default_when_no_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertTrue(er.is_reporting_enabled(Path(tmp)))
+
+    def test_reporting_enabled_when_field_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_dir = Path(tmp) / ".bedrock"
+            cfg_dir.mkdir()
+            (cfg_dir / "config.json").write_text(json.dumps({"git": {"strategy": "commit-push"}}))
+            self.assertTrue(er.is_reporting_enabled(Path(tmp)))
+
+    def test_reporting_disabled_when_field_false(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_dir = Path(tmp) / ".bedrock"
+            cfg_dir.mkdir()
+            (cfg_dir / "config.json").write_text(json.dumps({"error_reporting": False}))
+            self.assertFalse(er.is_reporting_enabled(Path(tmp)))
+
+    def test_reporting_enabled_when_field_true(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_dir = Path(tmp) / ".bedrock"
+            cfg_dir.mkdir()
+            (cfg_dir / "config.json").write_text(json.dumps({"error_reporting": True}))
+            self.assertTrue(er.is_reporting_enabled(Path(tmp)))
+
+    def test_reporting_walks_up_to_find_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_dir = Path(tmp) / ".bedrock"
+            cfg_dir.mkdir()
+            (cfg_dir / "config.json").write_text(json.dumps({"error_reporting": False}))
+            nested = Path(tmp) / "sub" / "deep"
+            nested.mkdir(parents=True)
+            self.assertFalse(er.is_reporting_enabled(nested))
+
+    def test_reporting_enabled_when_config_malformed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_dir = Path(tmp) / ".bedrock"
+            cfg_dir.mkdir()
+            (cfg_dir / "config.json").write_text("not json {{{")
+            self.assertTrue(er.is_reporting_enabled(Path(tmp)))
+
+    def test_reporting_enabled_when_field_is_null(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_dir = Path(tmp) / ".bedrock"
+            cfg_dir.mkdir()
+            (cfg_dir / "config.json").write_text('{"error_reporting": null}')
+            self.assertTrue(er.is_reporting_enabled(Path(tmp)))
+
+    def test_reporting_enabled_when_field_is_string(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_dir = Path(tmp) / ".bedrock"
+            cfg_dir.mkdir()
+            (cfg_dir / "config.json").write_text('{"error_reporting": "false"}')
+            self.assertTrue(er.is_reporting_enabled(Path(tmp)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/tests/test_detection.py
+++ b/hooks/tests/test_detection.py
@@ -1,0 +1,82 @@
+import unittest
+from pathlib import Path
+import sys
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOKS_DIR))
+
+import error_reporter as er
+
+
+class TestTechnicalErrors(unittest.TestCase):
+    def test_is_error_true_produces_one_error(self):
+        results = [{"tool_use_id": "x", "is_error": True, "content": "Traceback (most recent call last):\n  File \"a.py\", line 1, in <module>\n    raise ValueError()"}]
+        errors = er.detect_technical_errors(results)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["error_type"], "python_traceback")
+
+    def test_is_error_with_bash_failure_no_traceback(self):
+        results = [{"tool_use_id": "x", "is_error": True, "content": "bash: command not found: docling"}]
+        errors = er.detect_technical_errors(results)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["error_type"], "bash_failure")
+
+    def test_no_errors_when_is_error_false(self):
+        results = [{"tool_use_id": "x", "is_error": False, "content": "ok"}]
+        errors = er.detect_technical_errors(results)
+        self.assertEqual(errors, [])
+
+    def test_signature_captures_last_traceback_frame(self):
+        content = "Traceback (most recent call last):\n  File \"a.py\", line 1, in foo\n  File \"b.py\", line 2, in bar\nValueError: bad input"
+        results = [{"tool_use_id": "x", "is_error": True, "content": content}]
+        errors = er.detect_technical_errors(results)
+        self.assertIn("ValueError", errors[0]["signature"])
+        self.assertIn("b.py", errors[0]["signature"])
+
+    def test_traceback_in_non_error_result_is_still_caught(self):
+        content = "stderr: Traceback (most recent call last):\nValueError: oops"
+        results = [{"tool_use_id": "x", "is_error": False, "content": content}]
+        errors = er.detect_technical_errors(results)
+        self.assertEqual(len(errors), 1)
+
+
+class TestLogicalErrors(unittest.TestCase):
+    def test_graphify_invalid_pattern_matches(self):
+        text = "I ran the skill but graphify returned invalid output."
+        errors = er.detect_logical_errors(text)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["error_type"], "logical_graphify_invalid")
+
+    def test_entity_unwritable_pattern_matches(self):
+        text = "Failed to persist entity 'billing-api'."
+        errors = er.detect_logical_errors(text)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["error_type"], "logical_entity_unwritable")
+
+    def test_multiple_distinct_patterns_produce_multiple_errors(self):
+        text = "graphify returned invalid output. Failed to write entity 'x'."
+        errors = er.detect_logical_errors(text)
+        self.assertEqual(len(errors), 2)
+
+    def test_no_match_no_errors(self):
+        text = "Everything went fine."
+        errors = er.detect_logical_errors(text)
+        self.assertEqual(errors, [])
+
+    def test_signature_includes_pattern_id(self):
+        text = "graphify returned an invalid structure here"
+        errors = er.detect_logical_errors(text)
+        self.assertEqual(errors[0]["signature"], "matched pattern: graphify_invalid")
+
+
+class TestLogicalSignatureRedaction(unittest.TestCase):
+    def test_logical_signature_does_not_leak_user_content(self):
+        text = "graphify returned invalid output for customer acme-fintech-acquisition"
+        errors = er.detect_logical_errors(text)
+        self.assertEqual(len(errors), 1)
+        self.assertNotIn("acme-fintech", errors[0]["signature"])
+        self.assertEqual(errors[0]["signature"], "matched pattern: graphify_invalid")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/tests/test_hashing.py
+++ b/hooks/tests/test_hashing.py
@@ -1,0 +1,53 @@
+import unittest
+from pathlib import Path
+import sys
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOKS_DIR))
+
+import error_reporter as er
+
+
+class TestErrorHash(unittest.TestCase):
+    def test_hash_is_8_hex_chars(self):
+        h = er.error_hash("bedrock:teach", "python_traceback", 'File "a.py", line 1 | ValueError')
+        self.assertEqual(len(h), 8)
+        self.assertTrue(all(c in "0123456789abcdef" for c in h))
+
+    def test_hash_is_deterministic(self):
+        a = er.error_hash("bedrock:teach", "python_traceback", "ValueError: oops")
+        b = er.error_hash("bedrock:teach", "python_traceback", "ValueError: oops")
+        self.assertEqual(a, b)
+
+    def test_hash_normalizes_user_paths_in_signature(self):
+        a = er.error_hash("bedrock:teach", "python_traceback", 'File "/Users/alice/.claude/plugins/x/y/skills/teach/extract.py", line 1 | ValueError')
+        b = er.error_hash("bedrock:teach", "python_traceback", 'File "/Users/bob/.claude/plugins/x/y/skills/teach/extract.py", line 1 | ValueError')
+        self.assertEqual(a, b)
+
+    def test_hash_differs_when_skill_differs(self):
+        a = er.error_hash("bedrock:teach", "bash_failure", "command not found")
+        b = er.error_hash("bedrock:ask", "bash_failure", "command not found")
+        self.assertNotEqual(a, b)
+
+
+class TestDedupe(unittest.TestCase):
+    def test_dedupe_collapses_duplicates(self):
+        errs = [
+            {"error_type": "python_traceback", "signature": 'File "a.py", line 1 | ValueError', "raw": "x"},
+            {"error_type": "python_traceback", "signature": 'File "a.py", line 1 | ValueError', "raw": "x"},
+        ]
+        out = er.dedupe_by_hash(errs, skill="bedrock:teach")
+        self.assertEqual(len(out), 1)
+        self.assertIn("hash", out[0])
+
+    def test_dedupe_preserves_distinct(self):
+        errs = [
+            {"error_type": "python_traceback", "signature": 'File "a.py", line 1 | ValueError', "raw": "x"},
+            {"error_type": "python_traceback", "signature": 'File "b.py", line 2 | KeyError', "raw": "y"},
+        ]
+        out = er.dedupe_by_hash(errs, skill="bedrock:teach")
+        self.assertEqual(len(out), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/tests/test_issues.py
+++ b/hooks/tests/test_issues.py
@@ -1,0 +1,153 @@
+import json
+import os
+import time
+import unittest
+from pathlib import Path
+import sys
+import tempfile
+from unittest.mock import patch, MagicMock
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOKS_DIR))
+
+import error_reporter as er
+
+
+class TestIssueLookup(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cache_dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_returns_none_when_no_match_and_no_cache(self):
+        with patch("error_reporter._run_gh") as mock_gh:
+            mock_gh.return_value = (0, "[]", "")
+            issue = er.find_existing_issue("abcdef12", cache_dir=self.cache_dir)
+        self.assertIsNone(issue)
+
+    def test_returns_issue_when_gh_finds_one(self):
+        with patch("error_reporter._run_gh") as mock_gh:
+            mock_gh.return_value = (0, json.dumps([{"number": 42, "state": "open"}]), "")
+            issue = er.find_existing_issue("abcdef12", cache_dir=self.cache_dir)
+        self.assertEqual(issue, {"number": 42, "state": "open"})
+
+    def test_uses_cache_within_ttl(self):
+        cache_path = self.cache_dir / "issues-abcdef12.json"
+        cache_path.write_text(json.dumps({"issue": {"number": 99, "state": "open"}}))
+        with patch("error_reporter._run_gh") as mock_gh:
+            issue = er.find_existing_issue("abcdef12", cache_dir=self.cache_dir)
+        mock_gh.assert_not_called()
+        self.assertEqual(issue, {"number": 99, "state": "open"})
+
+    def test_cache_miss_after_ttl(self):
+        cache_path = self.cache_dir / "issues-abcdef12.json"
+        cache_path.write_text(json.dumps({"issue": None}))
+        old = time.time() - 600
+        os.utime(cache_path, (old, old))
+        with patch("error_reporter._run_gh") as mock_gh:
+            mock_gh.return_value = (0, json.dumps([{"number": 7, "state": "closed"}]), "")
+            issue = er.find_existing_issue("abcdef12", cache_dir=self.cache_dir)
+        mock_gh.assert_called_once()
+        self.assertEqual(issue, {"number": 7, "state": "closed"})
+
+    def test_returns_none_when_gh_command_fails(self):
+        with patch("error_reporter._run_gh") as mock_gh:
+            mock_gh.return_value = (1, "", "auth required")
+            issue = er.find_existing_issue("abcdef12", cache_dir=self.cache_dir)
+        self.assertIsNone(issue)
+
+
+class TestIssueDispatch(unittest.TestCase):
+    def setUp(self):
+        self.err = {
+            "hash": "abcdef12",
+            "error_type": "python_traceback",
+            "signature": 'File "x.py", line 1 | ValueError: oops',
+            "raw": 'Traceback ...\n  File "x.py", line 1\nValueError: oops',
+        }
+        self.skill = "bedrock:teach"
+
+    def test_creates_new_issue_when_none_exists(self):
+        with patch("error_reporter.find_existing_issue", return_value=None), \
+             patch("error_reporter._run_gh") as mock_gh:
+            mock_gh.return_value = (0, "https://github.com/iurykrieger/claude-bedrock/issues/100", "")
+            er.handle_error(self.err, self.skill)
+            args = mock_gh.call_args.args[0]
+            self.assertIn("create", args)
+            self.assertIn("--title", args)
+            title = args[args.index("--title") + 1]
+            self.assertIn("[bedrock][abcdef12]", title)
+            self.assertIn("teach", title)
+
+    def test_comments_when_open_issue_exists(self):
+        with patch("error_reporter.find_existing_issue", return_value={"number": 42, "state": "open"}), \
+             patch("error_reporter._run_gh") as mock_gh:
+            mock_gh.return_value = (0, "", "")
+            er.handle_error(self.err, self.skill)
+            args = mock_gh.call_args.args[0]
+            self.assertIn("comment", args)
+            self.assertIn("42", args)
+
+    def test_reopens_and_comments_when_closed(self):
+        with patch("error_reporter.find_existing_issue", return_value={"number": 42, "state": "closed"}), \
+             patch("error_reporter._run_gh") as mock_gh:
+            mock_gh.return_value = (0, "", "")
+            er.handle_error(self.err, self.skill)
+            calls = [c.args[0] for c in mock_gh.call_args_list]
+            self.assertIn("reopen", calls[0])
+            self.assertIn("comment", calls[1])
+
+    def test_issue_body_contains_redacted_signature(self):
+        err = {**self.err, "signature": '/Users/alice/.claude/plugins/x/y/skills/teach/extract.py | ValueError'}
+        with patch("error_reporter.find_existing_issue", return_value=None), \
+             patch("error_reporter._run_gh") as mock_gh:
+            mock_gh.return_value = (0, "https://...", "")
+            er.handle_error(err, self.skill)
+            args = mock_gh.call_args.args[0]
+            body = args[args.index("--body") + 1]
+            self.assertNotIn("/Users/alice", body)
+
+    def test_handle_error_swallows_gh_failures(self):
+        with patch("error_reporter.find_existing_issue", return_value=None), \
+             patch("error_reporter._run_gh", return_value=(1, "", "auth failed")):
+            er.handle_error(self.err, self.skill)
+
+
+class TestAuthFallback(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cache_dir = Path(self.tmp.name)
+        self.session_id = "test-session-123"
+        self.error = {
+            "hash": "deadbeef",
+            "error_type": "python_traceback",
+            "signature": "x",
+            "raw": "raw",
+        }
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_auth_failure_writes_local_log_and_session_flag(self):
+        with patch("error_reporter._run_gh", return_value=(127, "", "gh: command not found")), \
+             patch("error_reporter._cache_dir", return_value=self.cache_dir):
+            er.handle_error_with_fallback(self.error, "bedrock:teach", self.session_id)
+        log_path = self.cache_dir / "error-reporter.log"
+        flag_path = self.cache_dir / f".auth-failed-{self.session_id}"
+        self.assertTrue(log_path.exists())
+        self.assertTrue(flag_path.exists())
+        self.assertIn("deadbeef", log_path.read_text())
+
+    def test_subsequent_calls_in_same_session_skip_gh(self):
+        flag = self.cache_dir / f".auth-failed-{self.session_id}"
+        flag.touch()
+        with patch("error_reporter._run_gh") as mock_gh, \
+             patch("error_reporter._cache_dir", return_value=self.cache_dir):
+            er.handle_error_with_fallback(self.error, "bedrock:teach", self.session_id)
+        mock_gh.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/tests/test_main.py
+++ b/hooks/tests/test_main.py
@@ -1,0 +1,78 @@
+import io
+import json
+import unittest
+from pathlib import Path
+import sys
+import tempfile
+from unittest.mock import patch
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOKS_DIR))
+
+import error_reporter as er
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class TestMainPipeline(unittest.TestCase):
+    def _run_main(self, transcript_fixture: str, project_dir: Path | None = None) -> int:
+        payload = {
+            "session_id": "test-session",
+            "transcript_path": str(FIXTURES / transcript_fixture),
+        }
+        env = {"CLAUDE_PROJECT_DIR": str(project_dir or Path("/tmp"))}
+        with patch.object(sys, "stdin", io.StringIO(json.dumps(payload))), \
+             patch.dict("os.environ", env, clear=False):
+            return er.main()
+
+    def test_exits_when_no_bedrock(self):
+        with patch("error_reporter.handle_error_with_fallback") as mock_handle:
+            rc = self._run_main("transcript_no_bedrock.jsonl")
+        self.assertEqual(rc, 0)
+        mock_handle.assert_not_called()
+
+    def test_exits_when_bedrock_clean(self):
+        with patch("error_reporter.handle_error_with_fallback") as mock_handle:
+            rc = self._run_main("transcript_bedrock_clean.jsonl")
+        self.assertEqual(rc, 0)
+        mock_handle.assert_not_called()
+
+    def test_dispatches_on_traceback(self):
+        with patch("error_reporter.handle_error_with_fallback") as mock_handle:
+            rc = self._run_main("transcript_bedrock_traceback.jsonl")
+        self.assertEqual(rc, 0)
+        self.assertEqual(mock_handle.call_count, 1)
+        err, skill, session = mock_handle.call_args.args
+        self.assertEqual(skill, "bedrock:teach")
+        self.assertEqual(err["error_type"], "python_traceback")
+
+    def test_dispatches_on_logical_error(self):
+        with patch("error_reporter.handle_error_with_fallback") as mock_handle:
+            rc = self._run_main("transcript_bedrock_logical_error.jsonl")
+        self.assertEqual(rc, 0)
+        # Two logical patterns in the fixture: graphify_invalid + entity_unwritable
+        self.assertEqual(mock_handle.call_count, 2)
+
+    def test_opt_out_short_circuits_dispatch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_dir = Path(tmp) / ".bedrock"
+            cfg_dir.mkdir()
+            (cfg_dir / "config.json").write_text(json.dumps({"error_reporting": False}))
+            with patch("error_reporter.handle_error_with_fallback") as mock_handle:
+                rc = self._run_main("transcript_bedrock_traceback.jsonl", project_dir=Path(tmp))
+        self.assertEqual(rc, 0)
+        mock_handle.assert_not_called()
+
+    def test_handles_missing_transcript_path(self):
+        with patch.object(sys, "stdin", io.StringIO('{"session_id":"x"}')):
+            rc = er.main()
+        self.assertEqual(rc, 0)
+
+    def test_handles_malformed_stdin(self):
+        with patch.object(sys, "stdin", io.StringIO("not json")):
+            rc = er.main()
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/tests/test_perf.py
+++ b/hooks/tests/test_perf.py
@@ -1,0 +1,37 @@
+import io
+import json
+import time
+import unittest
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOKS_DIR))
+
+import error_reporter as er
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class TestPerformance(unittest.TestCase):
+    def test_fast_gate_completes_under_50ms_excluding_python_startup(self):
+        payload_str = json.dumps({
+            "session_id": "x",
+            "transcript_path": str(FIXTURES / "transcript_no_bedrock.jsonl"),
+        })
+
+        start = time.perf_counter()
+        for _ in range(100):  # average over 100 iterations
+            with patch.object(sys, "stdin", io.StringIO(payload_str)):
+                er.main()
+        elapsed_ms = (time.perf_counter() - start) * 1000 / 100
+
+        # 50ms per call is the budget for in-process work. Python interpreter startup
+        # (~50-100ms when invoked as a subprocess from the hook) is outside our control
+        # and measured separately in step 3.
+        self.assertLess(elapsed_ms, 50, f"fast gate too slow: {elapsed_ms:.2f}ms")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/tests/test_redaction.py
+++ b/hooks/tests/test_redaction.py
@@ -1,0 +1,93 @@
+import unittest
+from pathlib import Path
+import sys
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOKS_DIR))
+
+import error_reporter as er
+
+
+class TestRedaction(unittest.TestCase):
+    def test_user_home_path_redacted(self):
+        text = '/Users/iury.krieger/Documents/vault/people/alice.md'
+        out = er.redact(text)
+        self.assertNotIn("/Users/iury.krieger", out)
+        self.assertIn(".../", out)
+
+    def test_linux_home_redacted(self):
+        text = '/home/dev/.claude/plugins/x/file.py'
+        out = er.redact(text)
+        self.assertNotIn("/home/dev", out)
+        self.assertIn(".../", out)
+
+    def test_plugin_path_preserved_relative_to_plugin_root(self):
+        text = '/Users/foo/.claude/plugins/cache/x/skills/teach/scripts/extract.py'
+        out = er.redact(text)
+        self.assertIn("skills/teach/scripts/extract.py", out)
+
+    def test_session_id_redacted(self):
+        text = 'session_id=a1b2c3d4-5678-90ef-1234-567890abcdef failed'
+        out = er.redact(text)
+        self.assertNotIn("a1b2c3d4-5678", out)
+        self.assertIn("<id-redacted>", out)
+
+    def test_url_fully_redacted(self):
+        text = 'fetched https://confluence.acme.internal/wiki/spaces/PAY/pages/12345/Spec'
+        out = er.redact(text)
+        self.assertNotIn("confluence.acme.internal", out)
+        self.assertIn("<url-redacted>", out)
+
+    def test_entity_filenames_in_paths_redacted(self):
+        text = 'wrote /Users/foo/vault/people/alice-smith.md and teams/squad-payments.md'
+        out = er.redact(text)
+        self.assertNotIn("alice-smith", out)
+        self.assertNotIn("squad-payments", out)
+
+    def test_iso_timestamp_redacted(self):
+        text = 'failed at 2026-05-03T14:22:31Z during sync'
+        out = er.redact(text)
+        self.assertNotIn("2026-05-03T14:22:31Z", out)
+        self.assertIn("<ts-redacted>", out)
+
+    def test_idempotent(self):
+        text = 'session_id=a1b2c3d4-5678-90ef-1234-567890abcdef'
+        once = er.redact(text)
+        twice = er.redact(once)
+        self.assertEqual(once, twice)
+
+
+class TestRedactionPII(unittest.TestCase):
+    def test_email_redacted(self):
+        out = er.redact("error from user bob@example.com failed")
+        self.assertNotIn("bob@example.com", out)
+        self.assertIn("<email-redacted>", out)
+
+    def test_credit_card_like_redacted(self):
+        out = er.redact("card 4111 1111 1111 1111 declined")
+        self.assertNotIn("4111", out)
+        self.assertIn("<digits-redacted>", out)
+
+    def test_stripe_key_redacted(self):
+        out = er.redact("auth=sk_live_abcdef1234567890 failed")
+        self.assertNotIn("sk_live_abc", out)
+        self.assertIn("<key-redacted>", out)
+
+    def test_github_token_redacted(self):
+        out = er.redact("token ghp_abc123def456ghi789 invalid")
+        self.assertNotIn("ghp_abc", out)
+        self.assertIn("<key-redacted>", out)
+
+    def test_aws_key_redacted(self):
+        out = er.redact("aws AKIAIOSFODNN7EXAMPLE failed")
+        self.assertNotIn("AKIAIOSFODNN7", out)
+        self.assertIn("<key-redacted>", out)
+
+    def test_bare_wikilink_redacted(self):
+        out = er.redact("entity [[secret-customer-list]] not found")
+        self.assertNotIn("secret-customer-list", out)
+        self.assertIn("[[<entity>]]", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/tests/test_transcript.py
+++ b/hooks/tests/test_transcript.py
@@ -1,0 +1,58 @@
+import unittest
+from pathlib import Path
+import sys
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOKS_DIR))
+
+import error_reporter as er
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class TestFastGate(unittest.TestCase):
+    def test_returns_false_when_no_bedrock_in_transcript(self):
+        is_bedrock = er.contains_bedrock_invocation(FIXTURES / "transcript_no_bedrock.jsonl")
+        self.assertFalse(is_bedrock)
+
+    def test_returns_true_when_bedrock_in_transcript(self):
+        is_bedrock = er.contains_bedrock_invocation(FIXTURES / "transcript_bedrock_clean.jsonl")
+        self.assertTrue(is_bedrock)
+
+    def test_returns_false_when_transcript_missing(self):
+        is_bedrock = er.contains_bedrock_invocation(FIXTURES / "does_not_exist.jsonl")
+        self.assertFalse(is_bedrock)
+
+
+class TestExtraction(unittest.TestCase):
+    def test_extract_skill_invocation(self):
+        skill = er.extract_skill_invocation(FIXTURES / "transcript_bedrock_traceback.jsonl")
+        self.assertEqual(skill, "bedrock:teach")
+
+    def test_extract_tool_results(self):
+        results = er.extract_tool_results(FIXTURES / "transcript_bedrock_traceback.jsonl")
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0]["is_error"])
+        self.assertIn("ModuleNotFoundError", results[0]["content"])
+
+    def test_extract_assistant_text(self):
+        text = er.extract_assistant_text(FIXTURES / "transcript_bedrock_traceback.jsonl")
+        self.assertIn("docling is missing", text)
+
+    def test_extract_skill_invocation_returns_none_when_absent(self):
+        skill = er.extract_skill_invocation(FIXTURES / "transcript_no_bedrock.jsonl")
+        self.assertIsNone(skill)
+
+    def test_extraction_scoped_to_last_turn_ignores_old_errors(self):
+        # Fixture has an old traceback in turn 1, then a clean turn 2.
+        # Extraction should only return the LAST turn's content.
+        skill = er.extract_skill_invocation(FIXTURES / "transcript_bedrock_old_turn.jsonl")
+        # Last turn is "List my files" — not a /bedrock: invocation
+        self.assertIsNone(skill)
+        results = er.extract_tool_results(FIXTURES / "transcript_bedrock_old_turn.jsonl")
+        # The old traceback in turn 1 must NOT appear in results
+        self.assertEqual(results, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/index.html
+++ b/index.html
@@ -487,7 +487,7 @@
       <div class="workflow-pipeline">
         <div class="workflow-step"><div class="step-icon">&#9881;</div><div class="step-name">setup</div><div class="step-desc" data-i18n="wf_setup">Initialize vault structure and templates</div></div>
         <div class="workflow-arrow">&#8594;</div>
-        <div class="workflow-step"><div class="step-icon">&#128218;</div><div class="step-name">teach</div><div class="step-desc" data-i18n="wf_teach">Ingest from Confluence, GDocs, GitHub</div></div>
+        <div class="workflow-step"><div class="step-icon">&#128218;</div><div class="step-name">learn</div><div class="step-desc" data-i18n="wf_learn">Ingest from Confluence, GDocs, GitHub</div></div>
         <div class="workflow-arrow">&#8594;</div>
         <div class="workflow-step"><div class="step-icon">&#128279;</div><div class="step-name">preserve</div><div class="step-desc" data-i18n="wf_preserve">Create entities with bidirectional links</div></div>
         <div class="workflow-arrow">&#8594;</div>
@@ -552,7 +552,7 @@
       <div class="skills-grid">
         <div class="skill-card"><div class="skill-icon">&#9881;</div><span class="skill-name">/bedrock:setup</span><p data-i18n="sk_setup">Interactive wizard to scaffold directories, templates, and example entities. Pick a preset or go custom.</p></div>
         <div class="skill-card"><div class="skill-icon">&#128269;</div><span class="skill-name">/bedrock:ask</span><p data-i18n="sk_ask">Ask questions in natural language. Searches entities, follows wikilinks, and cross-references to build answers.</p></div>
-        <div class="skill-card"><div class="skill-icon">&#128218;</div><span class="skill-name">/bedrock:teach</span><p data-i18n="sk_teach">Feed it a Confluence page, Google Doc, GitHub repo, or CSV. It extracts entities and writes them to your vault.</p></div>
+        <div class="skill-card"><div class="skill-icon">&#128218;</div><span class="skill-name">/bedrock:learn</span><p data-i18n="sk_learn">Feed it a Confluence page, Google Doc, GitHub repo, or CSV. It extracts entities and writes them to your vault.</p></div>
         <div class="skill-card"><div class="skill-icon">&#128279;</div><span class="skill-name">/bedrock:preserve</span><p data-i18n="sk_preserve">Single write point for all entities. Detects type, matches existing files, creates or updates with bidirectional links.</p></div>
         <div class="skill-card"><div class="skill-icon">&#9878;</div><span class="skill-name">/bedrock:compress</span><p data-i18n="sk_compress">Finds duplicates, orphan entities, broken links, and stale content. Consolidates and reports vault health.</p></div>
         <div class="skill-card"><div class="skill-icon">&#128260;</div><span class="skill-name">/bedrock:sync</span><p data-i18n="sk_sync">Re-syncs entities with their external sources. Supports GitHub activity, contributor profiles, and source metadata.</p></div>
@@ -600,7 +600,7 @@
         hero_requires: 'Requires <a href="https://obsidian.md" target="_blank" rel="noopener">Obsidian</a> and <a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank" rel="noopener">Claude Code</a>',
         workflow_label: 'How It Works', workflow_title: 'Six skills, one workflow',
         workflow_subtitle: 'Set up your vault, ingest knowledge from any source, and let Bedrock keep it organized.',
-        wf_setup: 'Initialize vault structure and templates', wf_teach: 'Ingest from Confluence, GDocs, GitHub',
+        wf_setup: 'Initialize vault structure and templates', wf_learn: 'Ingest from Confluence, GDocs, GitHub',
         wf_preserve: 'Create entities with bidirectional links', wf_ask: 'Search and cross-reference your vault',
         wf_compress: 'Deduplicate and consolidate entities', wf_sync: 'Re-sync with external sources',
         uc_label: 'Built For', uc_title: 'Your knowledge, structured',
@@ -615,7 +615,7 @@
         sk_subtitle: "Each skill is a specialized agent that reads your vault conventions and acts accordingly.",
         sk_setup: 'Interactive wizard to scaffold directories, templates, and example entities. Pick a preset or go custom.',
         sk_ask: 'Ask questions in natural language. Searches entities, follows wikilinks, and cross-references to build answers.',
-        sk_teach: 'Feed it a Confluence page, Google Doc, GitHub repo, or CSV. It extracts entities and writes them to your vault.',
+        sk_learn: 'Feed it a Confluence page, Google Doc, GitHub repo, or CSV. It extracts entities and writes them to your vault.',
         sk_preserve: 'Single write point for all entities. Detects type, matches existing files, creates or updates with bidirectional links.',
         sk_compress: 'Finds duplicates, orphan entities, broken links, and stale content. Consolidates and reports vault health.',
         sk_sync: 'Re-syncs entities with their external sources. Supports GitHub activity, contributor profiles, and source metadata.',
@@ -629,7 +629,7 @@
         hero_requires: 'Requer <a href="https://obsidian.md" target="_blank" rel="noopener">Obsidian</a> e <a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank" rel="noopener">Claude Code</a>',
         workflow_label: 'Como Funciona', workflow_title: 'Seis skills, um fluxo',
         workflow_subtitle: 'Configure seu vault, ingira conhecimento de qualquer fonte e deixe o Bedrock manter tudo organizado.',
-        wf_setup: 'Inicializa estrutura e templates do vault', wf_teach: 'Ingere do Confluence, GDocs, GitHub',
+        wf_setup: 'Inicializa estrutura e templates do vault', wf_learn: 'Ingere do Confluence, GDocs, GitHub',
         wf_preserve: 'Cria entidades com links bidirecionais', wf_ask: 'Busca e cruza refer\u00eancias no vault',
         wf_compress: 'Deduplica e consolida entidades', wf_sync: 'Re-sincroniza com fontes externas',
         uc_label: 'Feito Para', uc_title: 'Seu conhecimento, estruturado',
@@ -644,7 +644,7 @@
         sk_subtitle: 'Cada skill \u00e9 um agente especializado que l\u00ea as conven\u00e7\u00f5es do vault e age de acordo.',
         sk_setup: 'Wizard interativo para criar diret\u00f3rios, templates e entidades de exemplo. Escolha um preset ou personalize.',
         sk_ask: 'Fa\u00e7a perguntas em linguagem natural. Busca entidades, segue wikilinks e cruza refer\u00eancias para construir respostas.',
-        sk_teach: 'Alimente com uma p\u00e1gina do Confluence, Google Doc, repo GitHub ou CSV. Extrai entidades e grava no vault.',
+        sk_learn: 'Alimente com uma p\u00e1gina do Confluence, Google Doc, repo GitHub ou CSV. Extrai entidades e grava no vault.',
         sk_preserve: 'Ponto \u00fanico de escrita. Detecta tipo, encontra arquivos existentes, cria ou atualiza com links bidirecionais.',
         sk_compress: 'Encontra duplicatas, entidades \u00f3rf\u00e3s, links quebrados e conte\u00fado obsoleto. Consolida e reporta a sa\u00fade do vault.',
         sk_sync: 'Re-sincroniza entidades com suas fontes externas. Suporta atividade GitHub, perfis de contribuidores e metadados.',

--- a/site/components/how-it-works.tsx
+++ b/site/components/how-it-works.tsx
@@ -6,10 +6,10 @@ import { AnimateIn } from "@/components/animate-in";
 const NARRATIVE_STEPS = [
   {
     number: "01",
-    title: "Teach it your sources",
+    title: "Learn from your sources",
     description:
       "Point Bedrock at a Confluence page, a GitHub repo, a Google Doc, or a CSV. It reads the source, extracts entities — people, systems, teams, topics — and classifies them automatically.",
-    command: "/bedrock:teach",
+    command: "/bedrock:learn",
     videoPath: "/videos/teach.mp4",
     accent: "purple" as const,
   },
@@ -48,7 +48,7 @@ export function HowItWorks() {
       <div className="max-w-5xl mx-auto px-6">
         <SectionHeader
           label="How It Works"
-          title="Teach, preserve, compress, ask"
+          title="Learn, preserve, compress, ask"
           subtitle="Four steps to turn scattered knowledge into a living, queryable graph."
         />
 

--- a/site/data/skills.ts
+++ b/site/data/skills.ts
@@ -20,9 +20,9 @@ export const skills: Skill[] = [
     videoPath: "/videos/setup.mp4",
   },
   {
-    id: "teach",
-    name: "teach",
-    command: "/bedrock:teach",
+    id: "learn",
+    name: "learn",
+    command: "/bedrock:learn",
     shortDescription: "Ingest from Confluence, GDocs, GitHub",
     description:
       "Ingest external sources — feed it a Confluence page, Google Doc, GitHub repo, or CSV. It extracts entities and writes them to your vault via /bedrock:preserve.",

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Adaptive vault reader skill. Receives a natural language question,
   searches the vault first (Glob/Grep, entity reads, wikilink traversal),
   then self-assesses whether more context is needed. Escalates to /graphify
-  for graph-level understanding or to /bedrock:teach for remote content ingestion
+  for graph-level understanding or to /bedrock:learn for remote content ingestion
   only when the vault alone is insufficient. Answers simple questions with zero
   graphify calls.
   Use when: "bedrock ask", "bedrock-ask", "/bedrock:ask", any question about the vault,
@@ -78,14 +78,14 @@ Extract `language` and other relevant fields for use in later phases.
 
 This skill receives a natural language question and answers it using an adaptive,
 vault-first approach. It always reads vault content first, then decides whether
-to escalate to graphify or /teach based on what's actually needed — not what the
+to escalate to graphify or /learn ased on what's actually needed — not what the
 question looks like in isolation.
 
 **You are an adaptive context orchestrator agent. You only READ — never write, edit, or delete files directly.**
 
-Writes happen exclusively through `/bedrock:teach` delegation (which flows through `/bedrock:preserve`).
+Writes happen exclusively through `/bedrock:learn` delegation (which flows through `/bedrock:preserve`).
 If the query reveals outdated or missing information and no remote source is available to ingest,
-suggest that the user run `/bedrock:preserve` or `/bedrock:teach` to update the vault.
+suggest that the user run `/bedrock:preserve` or `/bedrock:learn` to update the vault.
 
 ---
 
@@ -391,31 +391,31 @@ that appear directly relevant to answering the question:
 **Limit:** 2 URLs per `/bedrock:ask` invocation. If more than 2 relevant URLs exist,
 prioritize those most directly related to the question.
 
-#### 3-T.2 Invoke /bedrock:teach
+#### 3-T.2 Invoke /bedrock:learn
 
-For each URL, invoke `/bedrock:teach` via the Skill tool:
+For each URL, invoke `/bedrock:learn` via the Skill tool:
 
 ```
-/bedrock:teach <URL>
+/bedrock:learn <URL>
 
 Context: Ingesting to answer the question: "<original question>"
 ```
 
 **IMPORTANT:**
 - Invoke via the Skill tool — same delegation pattern as teach → preserve
-- `/teach` handles its own flow: fetch content, extract entities, present to user for confirmation, delegate to `/preserve`
-- `/ask` waits for `/teach` to complete
+- `/learn` handles its own flow: fetch content, extract entities, present to user for confirmation, delegate to `/preserve`
+- `/ask` waits for `/learn` to complete
 
 #### 3-T.3 Re-read newly created entities
 
-After `/teach` completes successfully:
-1. Search the vault for entities that were just created or updated (based on `/teach`'s output)
+After `/learn` completes successfully:
+1. Search the vault for entities that were just created or updated (based on `/learn`'s output)
 2. Read these new entities (frontmatter + body)
 3. Add them to the working set of vault entities for response composition
 
 #### 3-T.4 Best-effort fallback
 
-If `/teach` fails or the user declines the confirmation:
+If `/learn` fails or the user declines the confirmation:
 - Log: "Teach delegation for <URL> did not complete. Continuing with available content."
 - Continue to Phase 4 with whatever content is available
 - **Never block the response** because of a failed teach delegation
@@ -466,12 +466,12 @@ Build the response following these rules:
 
 4. **Escalation transparency:**
    - If graphify was used, note: "I consulted the knowledge graph for deeper context."
-   - If /teach was invoked, note: "I ingested [source] into the vault to answer this question."
+   - If /learn was invoked, note: "I ingested [source] into the vault to answer this question."
    - If vault-only was sufficient, no special note needed
 
 5. **When nothing is found:**
    - State explicitly: "I didn't find information about [X] in the vault."
-   - If relevant, suggest: "You can use `/bedrock:teach <URL>` to ingest a source about this topic."
+   - If relevant, suggest: "You can use `/bedrock:learn <URL>` to ingest a source about this topic."
    - **NEVER fabricate information.** Only respond with what was found.
 
 6. **Response prioritization (Zettelkasten hierarchy):**
@@ -497,9 +497,9 @@ Build the response following these rules:
 
 When appropriate, suggest actions to the user:
 
-- If information is outdated: "The vault may be outdated about [X]. Consider running `/bedrock:teach <source>` to update."
+- If information is outdated: "The vault may be outdated about [X]. Consider running `/bedrock:learn <source>` to update."
 - If the question revealed gaps: "I didn't find [Y] in the vault. If you have this information, you can use `/bedrock:preserve` to record it."
-- If the question is complex and the response incomplete: "For a more complete view, you may also want to run `/bedrock:teach <URL>` to ingest additional sources."
+- If the question is complex and the response incomplete: "For a more complete view, you may also want to run `/bedrock:learn <URL>` to ingest additional sources."
 
 ---
 
@@ -510,14 +510,14 @@ When appropriate, suggest actions to the user:
 | Vault-first principle | Phase 2 ALWAYS runs before any escalation. Read vault content first, decide later. Never skip Phase 2. |
 | LLM self-assessment | The decision to escalate is made by the LLM after reading vault content (Phase 3.1), not by a heuristic rule table. Use the guidance provided, but the LLM makes the final call. |
 | Escalation priority | When multiple outcomes apply: `needs_remote_content` > `needs_graphify` > `vault_sufficient`. Internalize first, then analyze. |
-| No direct writes | `/ask` NEVER writes, edits, or deletes files directly. All writes are delegated through `/bedrock:teach` → `/bedrock:preserve`. |
-| Teach delegation via Skill tool | Invoke `/bedrock:teach` via the Skill tool. `/teach` owns its confirmation gate. `/ask` cannot bypass it. |
+| No direct writes | `/ask` NEVER writes, edits, or deletes files directly. All writes are delegated through `/bedrock:learn` → `/bedrock:preserve`. |
+| Teach delegation via Skill tool | Invoke `/bedrock:learn` via the Skill tool. `/learn` owns its confirmation gate. `/ask` cannot bypass it. |
 | Graphify via Skill tool | Invoke `/graphify` via the Skill tool — NEVER call the Python API directly. |
 | Max graphify calls | Read `query.max_graphify_calls` from `.bedrock/config.json` (default: 3, valid range: 1–5). Only consumed when graphify is actually invoked. |
 | Graph unavailable warning | When `needs_graphify` but `graphify-out/graph.json` is missing, display `> [!warning]` callout with `/graphify build` instruction. Continue with vault-only content. |
 | Best-effort escalation | If graphify fails or teach fails or user declines: continue with available content. NEVER block the response. |
 | Limit of 15 entities | Do not read more than 15 entities total across Phase 2 + Phase 3 |
-| Limit of 2 teach URLs | Do not invoke `/bedrock:teach` for more than 2 URLs per `/bedrock:ask` invocation |
+| Limit of 2 teach URLs | Do not invoke `/bedrock:learn` for more than 2 URLs per `/bedrock:ask` invocation |
 | No fabrication | Respond ONLY with information found in the vault or obtained through escalation. Never fabricate data. |
 | Clarification before guessing | If the question is ambiguous, ask for clarification. Do not assume. |
 | Vault language with technical terms in English | Response always in the vault's configured language |

--- a/skills/confluence-to-markdown/SKILL.md
+++ b/skills/confluence-to-markdown/SKILL.md
@@ -3,14 +3,14 @@ name: confluence-to-markdown
 description: >
   Internal fetcher module for Confluence pages. Fetches content via Atlassian MCP (preferred),
   REST API with Basic Auth (fallback), or browser DOM extraction via Claude in Chrome (last resort)
-  and returns Markdown. Used by /bedrock:teach and /bedrock:sync — not intended for direct user invocation.
+  and returns Markdown. Used by /bedrock:learn and /bedrock:sync — not intended for direct user invocation.
 user_invocable: false
 allowed-tools: Bash, Read, Write, WebFetch, ToolSearch, mcp__plugin_atlassian_atlassian__*, mcp__claude-in-chrome__*
 ---
 
 # Confluence Fetcher
 
-Internal module — invoked by `/bedrock:teach` Phase 1 and `/bedrock:sync` Phase 2, not user-invocable.
+Internal module — invoked by `/bedrock:learn` Phase 1 and `/bedrock:sync` Phase 2, not user-invocable.
 
 Fetches a Confluence page and returns its content as Markdown. Three layers in fallback order:
 **MCP (preferred) → REST API → Browser DOM extraction.**
@@ -264,7 +264,7 @@ Check that the result is not empty and not a login page. If validation fails:
 
 ## Output Contract
 
-Return to the caller (`/bedrock:teach` or `/bedrock:sync`):
+Return to the caller (`/bedrock:learn` or `/bedrock:sync`):
 - **Markdown content**: the full page content as Markdown
 - **Page title**: extracted from MCP response, API response (`title` field), or browser extraction (`title` in JSON)
 - **Layer used**: MCP, API, or Browser

--- a/skills/gdoc-to-markdown/SKILL.md
+++ b/skills/gdoc-to-markdown/SKILL.md
@@ -4,14 +4,14 @@ description: >
   Internal fetcher module for Google Docs and Sheets. Fetches content via MCP (preferred, when available),
   Google API with bearer token or public URL export (fallback), or browser DOM extraction via Claude in
   Chrome (last resort) and returns Markdown.
-  Used by /bedrock:teach and /bedrock:sync — not intended for direct user invocation.
+  Used by /bedrock:learn and /bedrock:sync — not intended for direct user invocation.
 user_invocable: false
 allowed-tools: Bash, Read, Write, WebFetch, ToolSearch, mcp__claude-in-chrome__*
 ---
 
 # Google Docs & Sheets Fetcher
 
-Internal module — invoked by `/bedrock:teach` Phase 1 and `/bedrock:sync` Phase 2, not user-invocable.
+Internal module — invoked by `/bedrock:learn` Phase 1 and `/bedrock:sync` Phase 2, not user-invocable.
 
 Fetches a Google Docs document or Google Sheets spreadsheet and converts it to a local Markdown file.
 Supports both document types with automatic detection. Three layers in fallback order:
@@ -375,7 +375,7 @@ Write the Markdown content using the Write tool. Verify the file was written by 
 
 ### Return to caller
 
-Return to `/bedrock:teach` or `/bedrock:sync`:
+Return to `/bedrock:learn` or `/bedrock:sync`:
 - **Output file path**: `/tmp/gdoc_{docId}.md` or `/tmp/gsheet_{docId}.md`
 - **Document type**: Doc or Sheet
 - **Layer used**: MCP, API, Public Export, or Browser

--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -145,7 +145,7 @@ Also collect: `all_entity_slugs` — set of all entity slugs in the vault (for r
 
 2. If MISSING:
    - Status: **MISSING**
-   - Details: "graphify-out/ directory not found. Run `/bedrock:teach` on an actor repository to generate."
+   - Details: "graphify-out/ directory not found. Run `/bedrock:learn` on an actor repository to generate."
    - Skip remaining sub-checks.
 
 3. If EXISTS, check `<VAULT_PATH>/graphify-out/graph.json`:
@@ -155,7 +155,7 @@ Also collect: `all_entity_slugs` — set of all entity slugs in the vault (for r
 
 4. If graph.json MISSING:
    - Status: **MISSING**
-   - Details: "graph.json not found in graphify-out/. Run `/bedrock:teach` to generate."
+   - Details: "graph.json not found in graphify-out/. Run `/bedrock:learn` to generate."
    - Skip remaining sub-checks.
 
 5. If graph.json EXISTS, validate and extract stats:
@@ -184,7 +184,7 @@ Also collect: `all_entity_slugs` — set of all entity slugs in the vault (for r
    - Details: "graph.json exists but is not valid JSON."
 
 7. If valid:
-   - If stale (>30 days): Status: **WARN**, Details: "Graph.json is stale (>30 days). Last updated: {mod_date}. Run `/bedrock:teach` or `/bedrock:sync` to update."
+   - If stale (>30 days): Status: **WARN**, Details: "Graph.json is stale (>30 days). Last updated: {mod_date}. Run `/bedrock:learn` or `/bedrock:sync` to update."
    - If fresh: Status: **OK**, Details: "{total_nodes} nodes ({code_nodes} code). Last updated: {mod_date}."
 
 **Store:** `graphify_status`, `graphify_details`, `graphify_node_count`
@@ -342,7 +342,7 @@ Print the full report to the terminal.
 Based on findings, append actionable suggestions:
 
 - If orphan or dangling count > 0: "Run `/bedrock:compress` to detect and fix alignment issues (broken backlinks, missing entities)."
-- If graphify-out is MISSING or stale: "Run `/bedrock:teach` on an actor repository to generate or update the graph."
+- If graphify-out is MISSING or stale: "Run `/bedrock:learn` on an actor repository to generate or update the graph."
 - If old count > 0: "Review {N} stale entities for relevance. Consider updating or archiving."
 - If setup has issues: "Run `/bedrock:setup` to initialize missing directories or templates."
 - If all checks are OK: "Vault is healthy. No action needed."
@@ -368,7 +368,7 @@ Based on findings, append actionable suggestions:
 |---|---|
 | Read-only | NEVER use Write, Edit, Skill, or Agent tools. This skill only reads and reports. |
 | No git operations | NEVER run git add, commit, push, pull, or any mutating git command. |
-| No skill invocations | NEVER invoke /bedrock:compress, /bedrock:teach, /bedrock:preserve, or any other skill. Suggest them in text only. |
+| No skill invocations | NEVER invoke /bedrock:compress, /bedrock:learn, /bedrock:preserve, or any other skill. Suggest them in text only. |
 | Terminal output only | The report is printed to the terminal. No files are created or modified. |
 | Single-pass scan | Phase 1 scans once. All 5 checks in Phase 2 use the same scan data. |
 | Exclude templates | Always exclude `_template.md` and `_template_node.md` from entity counts and checks. |

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -1,19 +1,19 @@
 ---
-name: teach
+name: learn
 description: >
-  Teaches the Second Brain to recognize a new external data source. Fetches content from
+  Ingests an external data source into the Second Brain. Fetches content from
   Confluence, Google Docs, GitHub repositories, remote URLs, or any local file format
   supported by docling (DOCX, PPTX, XLSX, PDF, HTML, EPUB, images, Markdown, CSV, and more),
   converts non-markdown formats to markdown via docling, runs the /graphify extraction pipeline,
   and delegates entity persistence (including the graphify-output merge) to /bedrock:preserve.
-  Use when: "bedrock teach", "bedrock-teach", "teach", "ingest source", "import document", "/bedrock:teach",
+  Use when: "bedrock learn", "bedrock-learn", "learn", "ingest source", "import document", "/bedrock:learn",
   or when the user provides a Confluence, Google Docs, or GitHub URL, a remote file URL, or
   a local file path to incorporate into the vault.
 user_invocable: true
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, Agent, WebFetch, mcp__plugin_github_github__*, mcp__plugin_atlassian_atlassian__*
 ---
 
-# /bedrock:teach — External Source Ingestion into the Second Brain
+# /bedrock:learn — External Source Ingestion into the Second Brain
 
 ## Plugin Paths
 
@@ -30,7 +30,7 @@ Where `<base_dir>` is the path provided in "Base directory for this skill".
 
 ## Vault Resolution
 
-Resolve which vault to teach. This skill can be invoked from any directory.
+Resolve which vault to learn. This skill can be invoked from any directory.
 
 **Step 1 — Parse `--vault` flag:**
 Check if the input arguments include `--vault <name>`. If found, extract the vault name and remove it from the arguments (the remaining text is the source URL/path).
@@ -160,16 +160,16 @@ If no argument was provided: ask the user "What source do you want to ingest? Pr
 All content is fetched to a temporary directory. This is the single input path for `/graphify`.
 
 ```bash
-TEACH_TMP="/tmp/bedrock-teach-$(date +%s)"
-mkdir -p "$TEACH_TMP"
-echo "Temporary directory: $TEACH_TMP"
+LEARN_TMP="/tmp/bedrock-learn-$(date +%s)"
+mkdir -p "$LEARN_TMP"
+echo "Temporary directory: $LEARN_TMP"
 ```
 
 Store the path for use in subsequent phases.
 
 ### 1.3 Fetch content
 
-Execute the fetch strategy for the detected type. All content lands in `$TEACH_TMP/`.
+Execute the fetch strategy for the detected type. All content lands in `$LEARN_TMP/`.
 
 #### 1.3.1 GitHub repository
 
@@ -178,13 +178,13 @@ For GitHub URLs (e.g.: `https://github.com/acme-corp/billing-api`):
 1. Extract `owner/repo` and `repo-name` from the URL
 2. Clone the repository (shallow):
    ```bash
-   git clone --depth 1 <url> "$TEACH_TMP/<repo-name>"
+   git clone --depth 1 <url> "$LEARN_TMP/<repo-name>"
    ```
 3. GitHub MCP enrichment — call directly in main context (NOT via subagent — MCP permissions are not inherited):
    - `mcp__plugin_github_github__get_file_contents` → read the repo's README.md
    - `mcp__plugin_github_github__list_commits` → last 10 commits
    - `mcp__plugin_github_github__list_pull_requests` → last 5 PRs (state=all, sort=updated)
-4. Compile MCP results into a single markdown file and save as `$TEACH_TMP/<repo-name>/_github_metadata.md`
+4. Compile MCP results into a single markdown file and save as `$LEARN_TMP/<repo-name>/_github_metadata.md`
 
 > **Best-effort:** If any MCP call fails, continue with what was obtained. Do NOT block ingestion.
 
@@ -228,7 +228,8 @@ can be referenced from the concept/entity via `![[assets/<slug>/<filename>]]`.
 **Fallback:** If Word export fails (non-200), fall back to the internal confluence-to-markdown skill:
 1. Read the internal skill at `<base_dir>/../confluence-to-markdown/SKILL.md`
 2. Follow its instructions to parse the URL, choose layer (MCP → API → browser), and extract content
-3. Save the returned Markdown content to `$TEACH_TMP/<slug>.md`
+3. Save the returned Markdown content to `$LEARN_TMP/<slug>.md`
+   - `<slug>` is derived from the page title or URL path (kebab-case, lowercase)
    - Note: fallback loses images — only text is extracted
 
 If all methods are unavailable: warn the user and abort this source type.
@@ -239,7 +240,7 @@ For Google Docs or Sheets URLs:
 1. Read the internal skill at `<base_dir>/../gdoc-to-markdown/SKILL.md`
 2. Follow its instructions to parse the URL, detect document type (Doc vs Sheet), choose layer (MCP → API/public export → browser), and extract content
 3. The fetcher saves output to `/tmp/gdoc_{docId}.md` or `/tmp/gsheet_{docId}.md`
-4. Copy the output file to `$TEACH_TMP/<slug>.md`
+4. Copy the output file to `$LEARN_TMP/<slug>.md`
    - `<slug>` is derived from the document title or URL path (kebab-case, lowercase)
 
 If all three layers (MCP, API/public export, browser) are unavailable: warn the user with the guidance message from the fetcher module and abort this source type.
@@ -251,12 +252,12 @@ For any other HTTP/HTTPS URL, download the raw bytes so docling can operate on b
 
 1. Try `curl` first for true binary fidelity:
    ```bash
-   curl -fsSL -o "$TEACH_TMP/<filename-derived-from-url>" "<url>"
+   curl -fsSL -o "$LEARN_TMP/<filename-derived-from-url>" "<url>"
    ```
    - `<filename-derived-from-url>` preserves the URL's basename (including extension) when
      available; fall back to `<slug>.bin` if no extension is present.
 2. If `curl` is unavailable or the URL returns an HTML page (by Content-Type), fall back to
-   WebFetch and save the response text as `$TEACH_TMP/<slug>.md`.
+   WebFetch and save the response text as `$LEARN_TMP/<slug>.md`.
 
 If both attempts fail: warn "Could not fetch URL. Check if the URL is accessible." and abort.
 
@@ -268,7 +269,7 @@ For local files:
 1. Verify the file exists using Read (or `test -f`).
 2. Copy to tmp preserving the filename:
    ```bash
-   cp "<local-path>" "$TEACH_TMP/"
+   cp "<local-path>" "$LEARN_TMP/"
    ```
 
 No extension-based filtering — any existing file is accepted. Phase 1.5 decides conversion.
@@ -281,23 +282,23 @@ For local directories:
    ```bash
    rsync -a --exclude='.git' --exclude='node_modules' --exclude='bin' --exclude='obj' \
      --exclude='.vs' --exclude='TestResults' --exclude='packages' \
-     "<local-dir>/" "$TEACH_TMP/$(basename <local-dir>)/"
+     "<local-dir>/" "$LEARN_TMP/$(basename <local-dir>)/"
    ```
 
 ### 1.4 Phase 1 result
 
 At the end of this phase, you should have:
-- **`$TEACH_TMP`**: directory with all fetched content (local path for graphify)
+- **`$LEARN_TMP`**: directory with all fetched content (local path for graphify)
 - **`source_url`**: original URL or file path provided by the user
 - **`source_type`**: `confluence`, `gdoc`, `github-repo`, `remote-binary`, `local-file`, `local-dir`, or `manual`
 
-Report: "Phase 1 complete: Content fetched to `$TEACH_TMP`. Source type: `<source_type>`."
+Report: "Phase 1 complete: Content fetched to `$LEARN_TMP`. Source type: `<source_type>`."
 
 ---
 
 ## Phase 1.5 — Docling Conversion
 
-For every fetched file in `$TEACH_TMP` that is not a GitHub repo and is not already markdown
+For every fetched file in `$LEARN_TMP` that is not a GitHub repo and is not already markdown
 output from Confluence/GDoc fetchers, check whether docling supports the file type and, if so,
 convert it to markdown in place. GitHub repos (`source_type == "github-repo"`) skip this phase
 entirely and flow straight to graphify.
@@ -322,7 +323,7 @@ Phase 0 / `/bedrock:setup`). Compare by lowercase file extension:
 
 ### 1.5.2 Routing and failure rules
 
-For each file under `$TEACH_TMP` (excluding files inside `<repo-name>/` subdirectories of a
+For each file under `$LEARN_TMP` (excluding files inside `<repo-name>/` subdirectories of a
 `github-repo` source — skip those entirely):
 
 1. **Skip by type — already markdown or plain text:** if extension is `.md`, `.txt`, or `.csv`,
@@ -339,8 +340,8 @@ For each file under `$TEACH_TMP` (excluding files inside `<repo-name>/` subdirec
    to target a predictable path:
 
    ```bash
-   cd "$TEACH_TMP"
-   docling --from <auto> --to md --output "$TEACH_TMP" "<relative-file-path>"
+   cd "$LEARN_TMP"
+   docling --from <auto> --to md --output "$LEARN_TMP" "<relative-file-path>"
    ```
 
    Docling produces `<stem>.md` alongside the source. After a successful run:
@@ -352,14 +353,14 @@ For each file under `$TEACH_TMP` (excluding files inside `<repo-name>/` subdirec
      so this branch is defensive): leave the original file in place, record status
      `failed-fallback (raw passthrough)`, and continue with other files.
    - Otherwise (binary format like `.docx`, `.pdf`, etc.): **abort the entire skill**. Clean
-     up `$TEACH_TMP` (`rm -rf "$TEACH_TMP"`) and emit a clear error:
+     up `$LEARN_TMP` (`rm -rf "$LEARN_TMP"`) and emit a clear error:
      `ERROR: docling failed to convert <file>. Aborting ingestion. Temp directory cleaned up.`
      Do NOT proceed to graphify or preserve.
 
 ### 1.5.3 Phase 1.5 result
 
 At the end of Phase 1.5:
-- `$TEACH_TMP` contains markdown files (either originals or docling-converted).
+- `$LEARN_TMP` contains markdown files (either originals or docling-converted).
 - You have a per-file status map to surface in Phase 4's report:
   - `converted`: ran docling successfully
   - `passed-through`: skipped docling (markdown/plain text or unsupported type)
@@ -378,14 +379,14 @@ Use the Skill tool to invoke `/graphify`, directing its output to a per-run temp
 Phase 0 merge step, not by this skill.
 
 ```
-/graphify $TEACH_TMP --mode deep --obsidian --obsidian-dir $TEACH_TMP
+/graphify $LEARN_TMP --mode deep --obsidian --obsidian-dir $LEARN_TMP
 ```
 
-The convention used here: passing `--obsidian-dir $TEACH_TMP` makes graphify write its
-`graphify-out/` tree under `$TEACH_TMP/graphify-out/`. Store that path as:
+The convention used here: passing `--obsidian-dir $LEARN_TMP` makes graphify write its
+`graphify-out/` tree under `$LEARN_TMP/graphify-out/`. Store that path as:
 
 ```bash
-GRAPHIFY_OUT_NEW="$TEACH_TMP/graphify-out"
+GRAPHIFY_OUT_NEW="$LEARN_TMP/graphify-out"
 ```
 
 **IMPORTANT:**
@@ -408,7 +409,7 @@ fi
 
 **If graph.json is missing or empty:**
 - Warn the user: "graphify extraction failed — no graph produced. Check the content and try again."
-- Clean up tmp: `rm -rf "$TEACH_TMP"`
+- Clean up tmp: `rm -rf "$LEARN_TMP"`
 - Abort gracefully
 
 ### 2.3 Phase 2 result
@@ -427,19 +428,41 @@ Report: "Phase 2 complete: graphify extraction finished in `$GRAPHIFY_OUT_NEW`. 
 
 ### 3.1 Compile input for /preserve
 
-Pass the **temp** graphify output path and provenance metadata to `/bedrock:preserve`. The
-skill's Phase 0.2 merges this temp output into the vault's cumulative `graphify-out/`:
+#### 3.1.1 Derive `actor_context` (when applicable)
+
+`actor_context` tells `/preserve` that the entire corpus belongs to a single actor in the vault. When set, every `file_type=document/paper` graphify node is classified as `code` of that actor with `node_type ∈ {concept, decision}`, instead of as a global `concept`/`topic`/`fleeting`.
+
+Derivation rules by `source_type`:
+
+| `source_type` | `actor_context` derivation |
+|---|---|
+| `github-repo` | Use the cloned repo's `repo-name` (kebab-case) when an actor with the same slug exists in `<VAULT_PATH>/actors/`. Otherwise leave `actor_context` unset and let `/preserve` use corpus-agnostic classification. |
+| `local-dir` | Same rule as `github-repo`: use the directory's basename when it matches a vault actor; otherwise leave unset. |
+| `confluence`, `gdoc`, `remote-binary`, `local-file`, `manual` | Leave `actor_context` unset. These corpora are not scoped to a single actor by default. |
+
+**Multi-actor abort.** Before passing `actor_context`, scan the cloned repo's top-level subdirectories. If 2 or more of those subdirectory names match existing actor slugs in `<VAULT_PATH>/actors/`, abort with:
+
+> "Detected multiple actor candidates in this corpus: `<list>`. `/learn` only accepts a single-actor corpus per invocation. Run `/learn` separately against each actor, e.g.: `/learn <url>/<sub-actor-1>` and `/learn <url>/<sub-actor-2>`. If the repo is a true monorepo and you want a single ingestion, leave `actor_context` unset by passing `--no-actor-context` (graphify nodes will be classified globally instead of as `code` of one actor)."
+>
+> Do NOT proceed to /preserve.
+
+For non-`github-repo`/`local-dir` source types, no multi-actor scan is needed.
+
+#### 3.1.2 Build the input
+
+Pass the **temp** graphify output path, provenance metadata, and (optional) `actor_context` to `/bedrock:preserve`. The skill's Phase 0.2 merges this temp output into the vault's cumulative `graphify-out/`:
 
 ```
-graphify_output_path: $GRAPHIFY_OUT_NEW       # = $TEACH_TMP/graphify-out/
+graphify_output_path: $GRAPHIFY_OUT_NEW       # = $LEARN_TMP/graphify-out/
 source_url: <source_url from Phase 1>
 source_type: <source_type from Phase 1>
+actor_context: <derived in 3.1.1, or omitted>
 ```
 
 **IMPORTANT:**
-- `/teach` does NOT classify graphify nodes into entity types. Entity classification, filtering,
-  matching, and user confirmation are all `/bedrock:preserve`'s responsibility (Phase 1.3).
-- `/teach` does NOT merge the graph into the vault. That is `/bedrock:preserve`'s responsibility
+- `/learn` does NOT classify graphify nodes into entity types. Entity classification, filtering,
+  matching, and user confirmation are all `/bedrock:preserve`'s responsibility (Phase 1.3). `/learn`'s only contribution is the `actor_context` hint.
+- `/learn` does NOT merge the graph into the vault. That is `/bedrock:preserve`'s responsibility
   (Phase 0.2). We pass the per-run temp path; preserve merges and then reads from the merged
   `<VAULT_PATH>/graphify-out/`.
 
@@ -469,8 +492,8 @@ Record the result for use in the report (Phase 4).
 After `/bedrock:preserve` confirms completion, remove the temporary directory:
 
 ```bash
-rm -rf "$TEACH_TMP"
-echo "Temporary directory cleaned up: $TEACH_TMP"
+rm -rf "$LEARN_TMP"
+echo "Temporary directory cleaned up: $LEARN_TMP"
 ```
 
 **IMPORTANT:** Clean up AFTER /preserve confirms, not after graphify finishes.
@@ -482,7 +505,7 @@ and is used by `/bedrock:ask` for graph traversal.
 Present to the user:
 
 ```
-## /bedrock:teach — Report
+## /bedrock:learn — Report
 
 ### Ingested source
 - **Type:** <source_type>
@@ -499,7 +522,7 @@ Summary: N converted, M passed-through, P failed-fallback.
 (Omit this block entirely for `source_type == "github-repo"` where docling is bypassed.)
 
 ### Extraction (via /graphify)
-- **Graph:** N nodes, M edges, P communities (fresh run into $TEACH_TMP)
+- **Graph:** N nodes, M edges, P communities (fresh run into $LEARN_TMP)
 - **Report:** $GRAPHIFY_OUT_NEW/GRAPH_REPORT.md (before merge)
 
 ### Graphify merge (via /bedrock:preserve Phase 0.2)
@@ -541,15 +564,15 @@ Each entity above received in the `sources` frontmatter field:
 | Rule | Detail |
 |---|---|
 | Invoke /graphify via Skill tool | NEVER call graphify Python API directly (`graphify.detect`, `graphify.build`, `graphify.extract`, etc.). Always invoke via the Skill tool. |
-| All remote content fetched to /tmp | Every input type is fetched to `/tmp/bedrock-teach-<ts>/` before invoking graphify. graphify receives only a local path. |
-| /teach does NOT classify entities | Entity classification, filtering, matching, and user confirmation are `/bedrock:preserve`'s responsibility. /teach passes the graphify output path and provenance metadata. |
-| Delegate to /bedrock:preserve | ALL entities are persisted via `/bedrock:preserve` — teach does NOT create, update, or write vault entities. |
-| /teach does NOT merge graphify output into the vault | Graphify is invoked into `$TEACH_TMP/graphify-out/` (per-run temp dir); `/bedrock:preserve`'s Phase 0.2 merges that into `<VAULT_PATH>/graphify-out/`. /teach never writes directly to the vault's `graphify-out/`. |
+| All remote content fetched to /tmp | Every input type is fetched to `/tmp/bedrock-learn-<ts>/` before invoking graphify. graphify receives only a local path. |
+| /learn does NOT classify entities | Entity classification, filtering, matching, and user confirmation are `/bedrock:preserve`'s responsibility. /learn passes the graphify output path and provenance metadata. |
+| Delegate to /bedrock:preserve | ALL entities are persisted via `/bedrock:preserve` — learn does NOT create, update, or write vault entities. |
+| /learn does NOT merge graphify output into the vault | Graphify is invoked into `$LEARN_TMP/graphify-out/` (per-run temp dir); `/bedrock:preserve`'s Phase 0.2 merges that into `<VAULT_PATH>/graphify-out/`. /learn never writes directly to the vault's `graphify-out/`. |
 | Docling auto-install is silent | Phase 0 auto-installs docling if missing with a single status line — no user prompt. Fail the skill if install fails; direct the user to `/bedrock:setup`. |
 | Docling skipped for GitHub repos | `source_type == "github-repo"` skips Phase 1.5 entirely — cloned repos flow straight to graphify. |
 | Docling routing rule | Run docling on files with docling-supported extensions (see Phase 1.5.1). Pass-through for `.md`/`.txt`/`.csv` and for extensions not in docling's supported list. |
-| Docling failure fallback | On docling non-zero exit: if file is `.md`/`.txt`/`.csv`, continue with raw file. For any other extension, abort the entire skill and clean up `$TEACH_TMP`. |
-| Cleanup /tmp after /preserve confirms | Remove `/tmp/bedrock-teach-<ts>/` only after /preserve confirms completion, not after graphify finishes. |
+| Docling failure fallback | On docling non-zero exit: if file is `.md`/`.txt`/`.csv`, continue with raw file. For any other extension, abort the entire skill and clean up `$LEARN_TMP`. |
+| Cleanup /tmp after /preserve confirms | Remove `/tmp/bedrock-learn-<ts>/` only after /preserve confirms completion, not after graphify finishes. |
 | Provenance via source_url | ALWAYS include `source_url` and `source_type` when delegating to /bedrock:preserve. |
 | Internal fetcher skills | Read internal skills from `<base_dir>/../confluence-to-markdown/SKILL.md` and `<base_dir>/../gdoc-to-markdown/SKILL.md` for content fetching. Never invoke external skills. |
 | Best-effort for external sources | If MCP or fetch fails, warn and continue with what was obtained. Never block ingestion. |
@@ -558,3 +581,5 @@ Each entity above received in the `sources` frontmatter field:
 | Sensitive data | NEVER include credentials, tokens, passwords, PANs, CVVs. |
 | Vault resolution first | Resolve `VAULT_PATH` before any file operation — never assume CWD is the vault |
 | Pass --vault to /preserve | ALWAYS include `--vault <VAULT_NAME>` when delegating to `/bedrock:preserve` |
+| Derive `actor_context` for actor corpora | For `source_type ∈ {github-repo, local-dir}`, when the repo/dir basename matches an existing vault actor slug, pass `actor_context: <slug>` to `/preserve`. For other source types, leave `actor_context` unset. |
+| Multi-actor abort | Before passing `actor_context`, scan top-level subdirectories of the cloned repo. If 2+ subdirectories match existing actor slugs in `<VAULT_PATH>/actors/`, abort with guidance to split the invocation. Never auto-partition. |

--- a/skills/preserve/SKILL.md
+++ b/skills/preserve/SKILL.md
@@ -6,7 +6,7 @@ description: >
   (list of entities), free-form input (text, meeting notes, session context),
   or graphify output (graph.json + obsidian markdown from /graphify pipeline).
   Use when: "bedrock preserve", "bedrock-preserve", "save to vault", "record in vault", "/bedrock:preserve",
-  or when another skill (e.g., /bedrock:teach) needs to persist entities in the vault.
+  or when another skill (e.g., /bedrock:learn) needs to persist entities in the vault.
 user_invocable: true
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, mcp__plugin_github_github__*, mcp__plugin_atlassian_atlassian__*
 ---
@@ -101,7 +101,7 @@ If the pull fails:
 
 ### 0.2 Merge Incoming Graphify Output
 
-**When this runs:** Only when the skill was invoked with a `graphify_output_path` argument pointing at a graphify output directory (e.g., `/bedrock:teach` passes `$TEACH_TMP/graphify-out-new/`). Free-form text input and structured entity-list input skip this sub-phase entirely.
+**When this runs:** Only when the skill was invoked with a `graphify_output_path` argument pointing at a graphify output directory (e.g., `/bedrock:learn` passes `$TEACH_TMP/graphify-out-new/`). Free-form text input and structured entity-list input skip this sub-phase entirely.
 
 **Skip condition (backward compat):** If the input's `graphify_output_path` resolves to the same absolute path as `<VAULT_PATH>/graphify-out/`, skip this sub-phase. Legacy callers (and `/bedrock:sync` in its current form) point at the vault's own output directory — there is nothing to merge. Use `realpath` (or equivalent) to compare:
 
@@ -298,7 +298,7 @@ fi
 
 If the file does not exist, skip (nothing to mark).
 
-**Step 7 — Record merge stats for the Phase 7 report.** Capture `nodes_added`, `nodes_merged`, `edges_added` (from Step 3's Python stdout) and `stale_flag_set` (from Step 6). These values are threaded through to Phase 7's report block under a new **"Graphify merge"** section and returned in the skill's result payload to the caller (e.g., `/bedrock:teach`).
+**Step 7 — Record merge stats for the Phase 7 report.** Capture `nodes_added`, `nodes_merged`, `edges_added` (from Step 3's Python stdout) and `stale_flag_set` (from Step 6). These values are threaded through to Phase 7's report block under a new **"Graphify merge"** section and returned in the skill's result payload to the caller (e.g., `/bedrock:learn`).
 
 **Step 8 — Point subsequent phases at the merged location.** After the merge succeeds, set `graphify_output_path := <VAULT_PATH>/graphify-out/` for all downstream phases. Phase 1.3 (graphify-output parsing), Phase 2 (matching), and the rest of the flow read from the merged vault location — not from the original temp input.
 
@@ -310,26 +310,35 @@ If the file does not exist, skip (nothing to mark).
 
 ### 1.1 Structured input
 
-When called by another skill (e.g., `/bedrock:teach`) or when the user provides an explicit list.
-The format is a list of entities, each with:
+When called by another skill (e.g., `/bedrock:learn`) or when the user provides an explicit list.
+The format is an optional top-level header followed by a list of entities:
 
 ```yaml
-- type: actor | person | team | concept | topic | discussion | project | fleeting | code
-  name: "canonical entity name"
-  action: create | update
-  content: "content to include in the entity body"
-  relations:
-    actors: ["actor-slug-1", "actor-slug-2"]
-    people: ["person-slug-1"]
-    teams: ["team-slug-1"]
-    concepts: ["concept-slug-1"]
-    topics: ["topic-slug-1"]
-    discussions: ["discussion-slug-1"]
-    projects: ["project-slug-1"]
-    code: ["node-slug-1"]
-  source: "github | confluence | jira | session | manual | gdoc | csv | graphify"
-  metadata: {}  # additional frontmatter fields specific to the type
+# Optional top-level header — applies to all entities in the batch
+actor_context: <actor-name>  # optional, kebab-case slug of an actor in the vault.
+                             # When present, /preserve treats the batch as scoped to that actor:
+                             # graphify nodes of file_type=document/paper become `code` of this actor
+                             # with node_type ∈ {concept, decision} (see Phase 1.3 step 4).
+
+entities:
+  - type: actor | person | team | concept | topic | discussion | project | fleeting | code
+    name: "canonical entity name"
+    action: create | update
+    content: "content to include in the entity body"
+    relations:
+      actors: ["actor-slug-1", "actor-slug-2"]
+      people: ["person-slug-1"]
+      teams: ["team-slug-1"]
+      concepts: ["concept-slug-1"]
+      topics: ["topic-slug-1"]
+      discussions: ["discussion-slug-1"]
+      projects: ["project-slug-1"]
+      code: ["node-slug-1"]
+    source: "github | confluence | jira | session | manual | gdoc | csv | graphify"
+    metadata: {}  # additional frontmatter fields specific to the type
 ```
+
+If the input is a bare list (no `entities:` key, no `actor_context`), accept it as a list of entities with `actor_context = null`. This preserves backward compatibility with callers that pre-date the field.
 
 If the input follows this format (or something close): parse directly and go to Phase 2.
 
@@ -366,13 +375,14 @@ Convert the result to the structured format from section 1.1 and proceed.
 
 ### 1.3 Graphify output input
 
-When called by `/bedrock:teach` (or any skill) with a graphify output reference,
+When called by `/bedrock:learn` (or any skill) with a graphify output reference,
 OR when the user invokes `/bedrock:preserve` directly pointing at a `graphify-out/` directory:
 
 **Input format:**
 - `graphify_output_path`: path to `graphify-out/` directory
 - `source_url`: original external source URL/path (optional — may not be present for manual invocation)
 - `source_type`: type of external source (optional)
+- `actor_context`: kebab-case slug of an actor in the vault (optional). When present, the entire corpus is treated as belonging to that actor: `file_type=document/paper` nodes are classified as `code` of that actor with `node_type ∈ {concept, decision}` instead of as global `concept`/`topic`/`fleeting`. When absent, classification falls back to the corpus-agnostic logic (concept global / topic / fleeting).
 
 **Detection:** If the input contains a path ending in `graphify-out/` or `graphify-out`,
 or references `graph.json`, treat as graphify output input.
@@ -391,48 +401,77 @@ or references `graph.json`, treat as graphify output input.
    - If obsidian file doesn't exist for a node: fall back to graph.json metadata alone
 
 3. **Read analysis** from `graphify_output_path/.graphify_analysis.json` (if exists):
-   - Extract community assignments, god nodes, community labels
+   - Extract community assignments (`community_id` per node), god nodes (`is_god_node`), community labels
    - Use community labels to inform `domain/*` tags when creating entities
+   - If absent or `stale: true`, downstream steps fall back to graph-only signals (no community-aware grouping)
 
-4. **Classify graphify nodes into vault entity types** — /preserve owns this classification:
-   - Read ALL entity definitions from plugin (see "Plugin Paths")
-   - For each graphify node, classify:
-     - `file_type: code` → `code` (actor inferred from `source_file` path or repo name in the path)
-     - `file_type: document` or `file_type: paper` → check for concept first: if the node describes a pattern, principle, technique, protocol, or abstraction AND is self-contained AND is not specific to a single actor → `concept`
-     - `file_type: document` (non-concept) → classify using entity definitions ("When to create" / "When NOT to create" / "How to distinguish")
-     - `file_type: paper` (non-concept) → `topic` or `fleeting` depending on completeness criteria
-     - God nodes (high degree in `.graphify_analysis.json`) → consider as `actor`, `concept`, or `topic`
-     - Apply Zettelkasten classification (section 1.4): if content doesn't meet completeness criteria → `fleeting`
+4. **Read configuration** from `<VAULT_PATH>/.bedrock/config.json` (best-effort):
+   - `code.max_per_actor`: integer, default `200`. Per-actor cap on the number of `code` candidates produced from this corpus. No absolute global cap.
+   - `code.cluster_threshold`: float, default `0.85`. Minimum `semantically_similar_to.confidence_score` for two nodes to be grouped into the same `code` candidate.
+   - If `.bedrock/config.json` is missing or has no `code` block, use the defaults silently.
 
-5. **Filter relevant nodes:**
-   - For code entities: select top ~50 by relevance (degree > average, or label contains "Service", "Controller", "Client", "Factory", "Handler", "Mapper", "Gateway", "Provider"). Exclude test nodes (labels with "Test", "Tests", "Builder", "Mock", "Fake") and trivial nodes (getters, setters, simple DTOs).
-   - For document/paper nodes: include all.
+5. **Group nodes by semantic similarity** (BEFORE filtering and classification) — produces clusters that will each become at most one `code` candidate:
+   - Build clusters by union-find:
+     - Two nodes are in the same cluster if there is a `semantically_similar_to` edge between them with `confidence_score ≥ code.cluster_threshold`.
+     - OR they share the same `community_id` (from `.graphify_analysis.json`) AND at least one of them is `is_god_node` OR both have `edge_count ≥ 2`. This guards against weakly-tied community co-membership.
+   - If `.graphify_analysis.json` is absent or stale, only the `semantically_similar_to` rule applies.
+   - Singletons (nodes with no qualifying neighbor) form their own cluster of size 1.
+   - Each cluster carries: `cluster_id` (synthetic), `member_node_ids[]` (the union of node `id`s — this becomes the `graphify_node_ids` array of the resulting `code` entity), `representative` (the node with highest degree in the cluster — used for `label`, `source_file`, etc.).
+   - Hard cap: maximum 50 nodes per cluster (defensive — runaway clusters indicate bad threshold).
 
-6. **Match against existing vault** — Use existing textual matching logic from Phase 2 (filename, name, aliases, `graphify_node_id`). Mark matched nodes as `update`, unmatched as `create`.
+6. **Classify clusters into vault entity types** — /preserve owns this classification.
+   Read ALL entity definitions from the plugin (see "Plugin Paths") and apply:
 
-7. **Build internal structured format** for each classified + filtered entity:
-   - `type`: from classification (step 4)
-   - `name`: from graphify node `label` (kebab-cased for filename)
-   - `action`: `create` or `update` (from step 6 matching)
-   - `content`: from obsidian markdown file body (or generate from graph.json metadata if no obsidian file)
-   - `relations`: from graph.json edges (convert node ids to entity slugs via kebab-case)
-   - `source`: from input `source_type` (or `"graphify"` if not provided)
-   - `source_url`: from input `source_url` (if provided)
-   - `source_type`: from input `source_type` (if provided)
-   - `metadata`: for code entities, include:
-     - `graphify_node_id`: node `id` from graph.json
-     - `actor`: wikilink of the parent actor (inferred from `source_file` path)
-     - `node_type`: infer from context (`function`, `class`, `module`, `interface`, `endpoint`)
-     - `source_file`: relative path from graph.json
-     - `confidence`: from the strongest edge connected to the node (`EXTRACTED` > `INFERRED` > `AMBIGUOUS`)
-   - `metadata`: for concepts (from graphify), include:
-     - `graphify_node_id`: node `id` from graph.json
-     - `confidence`: from the strongest edge connected to the node (`EXTRACTED` > `INFERRED` > `AMBIGUOUS`)
+   **When `actor_context` is present** (single-actor corpus):
+   - `file_type: code` clusters → `code` for the actor, `node_type` ∈ {`function`, `class`, `module`, `interface`, `endpoint`} inferred from the representative node's label/edges.
+   - `file_type: document` or `file_type: paper` clusters → `code` for the actor:
+     - `node_type: decision` if the representative node has `rationale_for` edges OR the label/text contains decision markers (e.g., "ADR", "RFC", "decision", "chose", "decided").
+     - `node_type: concept` otherwise.
+   - The cluster's `actor` field is set to `[[<actor_context>]]` for all entities.
 
-8. **Proceed to Phase 3** (Change Proposal) — present the classified entity list for user confirmation, then execute writes as normal (Phases 4-7).
+   **When `actor_context` is absent** (corpus-agnostic):
+   - `file_type: code` clusters → `code` (parent actor inferred from `source_file` path or repo name in the path; if no actor can be inferred, classify as `fleeting`).
+   - `file_type: document` or `file_type: paper` clusters → check for concept first: if the representative node describes a pattern, principle, technique, protocol, or abstraction AND is self-contained AND is not specific to a single actor → `concept` (global).
+     - Non-concept document → classify using entity definitions ("When to create" / "When NOT to create" / "How to distinguish").
+     - Non-concept paper → `topic` or `fleeting` depending on completeness criteria.
+   - God nodes (`is_god_node`) → consider as `actor`, `concept`, or `topic`.
+   - Apply Zettelkasten classification (section 1.4): if content doesn't meet completeness criteria → `fleeting`.
 
-> **Note:** When invoked directly by the user (not via /teach), the user confirmation in Phase 3
-> is the only gate before writes. When invoked via /teach, /teach has already shown the user
+7. **Filter relevant clusters** (applied to `code` candidates only — non-code classifications keep their existing inclusion logic):
+   - **Inclusion predicate:** representative node's strongest edge has `confidence ∈ {EXTRACTED, INFERRED}` AND at least one of:
+     - `is_god_node` (from `.graphify_analysis.json`),
+     - `degree > community_average_degree` (from `.graphify_analysis.json`; if analysis absent, use overall graph average),
+     - `edge_count ≥ 2`.
+   - **Exclusion:** representative label matches trivial patterns (case-insensitive substring of `Test`, `Tests`, `Mock`, `Fake`, `Builder`, `Stub`, `Fixture`) or the cluster only contains nodes flagged trivial by graphify.
+   - **Per-actor cap:** group surviving `code` candidates by their resolved `actor`. Within each actor, rank by `is_god_node` (true first) > `degree` > `edge_count`. Keep the top `code.max_per_actor` (default `200`); discard the rest with a warning in the report listing how many were dropped per actor.
+   - **No English keyword regex.** The previous label allowlist (`Service|Controller|...`) is removed.
+   - For non-`code` classifications (concept global, topic, fleeting): include all that pass classification.
+
+8. **Match against existing vault** — Use the textual matching logic from Phase 2 (filename, name, aliases, graphify ids). For `code` entities, the graphify-id match accepts both legacy singular `graphify_node_id` and the new `graphify_node_ids` array — match if the cluster's `member_node_ids` set intersects the entity's existing id set. Mark matched clusters as `update`, unmatched as `create`.
+
+9. **Build internal structured format** for each classified + filtered cluster:
+   - `type`: from classification (step 6).
+   - `name`: kebab-cased label of the cluster's `representative` node.
+   - `action`: `create` or `update` (from step 8 matching).
+   - `content`: body of the obsidian markdown file matching the representative's id (or generate from graph.json metadata if no obsidian file). When the cluster has multiple members, include a brief "Grouped from N graphify nodes" note in the body listing the member ids — this preserves traceability.
+   - `relations`: from graph.json edges of all member nodes (convert node ids to entity slugs via kebab-case; deduplicate).
+   - `source`: from input `source_type` (or `"graphify"` if not provided).
+   - `source_url`: from input `source_url` (if provided).
+   - `source_type`: from input `source_type` (if provided).
+   - `metadata`: for `code` entities, include:
+     - `graphify_node_ids`: array — the cluster's `member_node_ids` (always written as array even when size is 1).
+     - `actor`: wikilink of the parent actor (`[[<actor_context>]]` when set; otherwise inferred).
+     - `node_type`: from step 6.
+     - `source_file`: relative path from the representative node.
+     - `confidence`: strongest edge confidence across all member nodes (`EXTRACTED` > `INFERRED` > `AMBIGUOUS`).
+   - `metadata`: for `concept` (global) entities from graphify, include:
+     - `graphify_node_ids`: array.
+     - `confidence`: strongest edge confidence across all members.
+
+10. **Proceed to Phase 3** (Change Proposal) — present the classified cluster list for user confirmation, then execute writes as normal (Phases 4-7).
+
+> **Note:** When invoked directly by the user (not via /learn), the user confirmation in Phase 3
+> is the only gate before writes. When invoked via /learn, /learn has already shown the user
 > the graphify report (god nodes, communities) providing context for the confirmation.
 
 ### 1.4 Zettelkasten Classification
@@ -442,7 +481,7 @@ Consult the plugin's entity definitions ("Completeness Criteria" section) to det
 
 **Classification rule:**
 - If the content meets the completeness criteria of a permanent type (actor, person, team) → classify as permanent
-- If the content has `graphify_node_id` and `actor` defined → classify as `code` (permanent extension, sub-entity of actor)
+- If the content has a non-empty `graphify_node_ids` array (or legacy singular `graphify_node_id`) and `actor` defined → classify as `code` (permanent extension, sub-entity of actor)
 - If the content defines a pattern, principle, technique, protocol, or abstraction that is self-contained and actor-independent → classify as `concept` (permanent)
 - If the content meets the completeness criteria of a bridge type (topic, discussion) → classify as bridge
 - If the content meets the completeness criteria of an index type (project) → classify as index
@@ -456,7 +495,7 @@ Consult the plugin's entity definitions ("Completeness Criteria" section) to det
 
 **When in doubt, err on the side of fleeting** — it is safer to capture as fleeting and promote later than to create an incomplete permanent entity.
 
-If the input came from another skill (e.g., `/bedrock:teach`) and already includes a classification suggestion (`type: fleeting`), respect the suggestion but validate against the criteria above.
+If the input came from another skill (e.g., `/bedrock:learn`) and already includes a classification suggestion (`type: fleeting`), respect the suggestion but validate against the criteria above.
 
 If no input was provided: ask the user "What would you like to preserve in the vault? Provide text, meeting notes, or a list of entities."
 
@@ -493,7 +532,7 @@ For each file found, extract:
 - `filename` (without extension) — canonical identifier
 - `name` (or `title`) from frontmatter — human-readable name
 - `aliases` from frontmatter — alternative names
-- `graphify_node_id` from frontmatter — for code entities (if present)
+- `graphify_node_ids` from frontmatter — for code entities (if present, accept both the new array form and the legacy singular `graphify_node_id` string; normalize to a set of ids per entity)
 
 ### 2.2 Textual matching
 
@@ -505,7 +544,7 @@ For each entity from the input, check if it already exists in the vault:
 2. **Match by name/title field** (case-insensitive): `"Billing API"` finds `billing-api.md`
 3. **Match by aliases** (case-insensitive): `"BillingAPI"` finds `billing-api.md` if alias contains "BillingAPI"
 4. **Match by filename without hyphens** (case-insensitive): `billing-api` → `billingapi` finds "BillingAPI"
-5. **Match by graphify_node_id** (for code entities): exact match by `graphify_node_id` in frontmatter. This is the most reliable match for code entities and takes priority over the others when present.
+5. **Match by graphify ids** (for code entities): set intersection between the input cluster's `graphify_node_ids` (array) and the vault entity's id set, where the vault entity's id set is normalized from EITHER `graphify_node_ids` (array, current schema) OR the legacy singular `graphify_node_id` (string treated as a 1-element set). Any non-empty intersection is a match. This is the most reliable match for code entities and takes priority over the others when present.
 
 **Safety rules:**
 - DO NOT match by substrings of 3 characters or fewer (e.g., "api" should not match everything)
@@ -635,7 +674,8 @@ When creating a code entity:
 3. **Create code entity:** use template `actors/_template_node.md`
    - Save to `actors/<actor>/nodes/<node-slug>.md`
    - Filename: kebab-case of the node's `name` (e.g., `ProcessTransaction` → `process-transaction.md`)
-   - Fill `graphify_node_id`, `actor`, `node_type`, `source_file`, `confidence` from the input
+   - Fill `graphify_node_ids` (array — always written as a list, even of size 1), `actor`, `node_type`, `source_file`, `confidence` from the input
+   - Backward compat at write time: if the input still carries the legacy singular `graphify_node_id` (string), normalize it to `graphify_node_ids: [<id>]` before writing. Never persist the singular form.
    - Inherit `domain/*` tags from the parent actor
    - Generate at least 1 alias (human-readable name + camelCase if applicable)
 4. **Bidirectional backlink:**
@@ -749,7 +789,7 @@ Append to the `## Temas Estratégicos` section:
 
 ### 4.3 Populate `sources` field (when applicable)
 
-If the input contains `source_url` and `source_type` (provided by `/bedrock:teach` or another caller):
+If the input contains `source_url` and `source_type` (provided by `/bedrock:learn` or another caller):
 
 **When creating an entity:**
 - Add to frontmatter:
@@ -830,6 +870,123 @@ For frontmatter-based links (team↔actor, team↔person, person↔team, etc.): 
 
 ---
 
+## Phase 6.5 — Sync Graph Back-Pointers
+
+**Objective:** Propagate `vault_entity_path` to the corresponding nodes in `<VAULT_PATH>/graphify-out/graph.json`, closing the bidirectional bridge between each `code` entity touched in this run and the graphify nodes it materializes.
+
+This phase runs AFTER bidirectional linking (Phase 5) and BEFORE the git workflow (Phase 6), so the back-pointer change lands in the same commit as the entities.
+
+### 6.5.1 Defensive cleanup
+
+Remove any orphaned staging file from a prior interrupted run before doing anything else:
+
+```bash
+rm -f "<VAULT_PATH>/graphify-out/graph.json.staging" 2>/dev/null || true
+```
+
+This is idempotent and never fails the phase.
+
+### 6.5.2 Best-effort detection
+
+Locate the vault's cumulative graph file:
+
+```bash
+GRAPH_PATH="<VAULT_PATH>/graphify-out/graph.json"
+test -s "$GRAPH_PATH" && echo "EXISTS" || echo "MISSING"
+```
+
+If the path does NOT exist, OR the file is empty (`-s` returns false), OR JSON parsing fails:
+- Record `phase_6_5_status = "skipped"` and `phase_6_5_reason` (`"missing"`, `"empty"`, or `"invalid_json"`).
+- Skip directly to Phase 6 — do NOT fail `/preserve`.
+- The Phase 7 report includes a warning surface (see §6.5.6 below).
+
+If the file exists and parses, continue.
+
+### 6.5.3 Collect target node ids from touched `code` entities
+
+Iterate over every entity created or updated in Phase 4 with `type: code`. For each one, normalize the graphify ids to a set:
+
+```python
+ids = set()
+fm = entity.frontmatter
+if isinstance(fm.get("graphify_node_ids"), list):
+    ids.update(fm["graphify_node_ids"])
+if isinstance(fm.get("graphify_node_id"), str):  # legacy singular — backward compat
+    ids.add(fm["graphify_node_id"])
+```
+
+Build a working map: `id → vault_entity_path` where `vault_entity_path` is the path of the entity file relative to `<VAULT_PATH>` (e.g. `actors/billing-api/nodes/process-transaction.md`).
+
+If the touched-code-entities set is empty (run touched no `code` entities), skip directly to Phase 6 with `phase_6_5_status = "skipped"`, `phase_6_5_reason = "no_code_entities"`.
+
+### 6.5.4 Locate and update graph nodes (atomic write)
+
+Read `graph.json` and write the updated graph to a staging file:
+
+```bash
+python3 - <<'PY'
+import json, pathlib, sys
+
+graph_path = pathlib.Path("<VAULT_PATH>/graphify-out/graph.json")
+staging_path = graph_path.with_suffix(".json.staging")
+
+with graph_path.open() as f:
+    graph = json.load(f)
+
+# Map from id → vault_entity_path was prepared in §6.5.3 — passed in as JSON.
+target_map = json.loads("""<TARGET_MAP_JSON>""")
+
+nodes_updated = 0
+nodes_unmatched_ids = []
+for node in graph.get("nodes", []):
+    nid = node.get("id")
+    if nid in target_map:
+        # Idempotency by overwrite: always set, even if already present.
+        node["vault_entity_path"] = target_map[nid]
+        nodes_updated += 1
+
+# Detect ids that did not match any node (graph diverged from vault — possible re-run of /graphify).
+matched_ids = {n["id"] for n in graph.get("nodes", []) if "id" in n}
+nodes_unmatched_ids = [tid for tid in target_map.keys() if tid not in matched_ids]
+
+with staging_path.open("w") as f:
+    json.dump(graph, f, indent=2, ensure_ascii=False)
+
+print(json.dumps({
+    "nodes_updated": nodes_updated,
+    "unmatched_ids": nodes_unmatched_ids,
+}))
+PY
+```
+
+If the Python block exits non-zero (parse error, write error, etc.), do NOT run the `mv` — the original `graph.json` stays intact. Capture the error message, set `phase_6_5_status = "failed"`, `phase_6_5_reason = "<error>"`, and skip to Phase 6 without aborting `/preserve`. The vault's git state remains valid because no rename occurred.
+
+### 6.5.5 Atomic swap
+
+If the Python block succeeded:
+
+```bash
+mv "<VAULT_PATH>/graphify-out/graph.json.staging" "<VAULT_PATH>/graphify-out/graph.json"
+```
+
+`mv` on the same filesystem is atomic at the filesystem level — readers either see the old or the new file, never a half-written one. Set `phase_6_5_status = "applied"` and capture `nodes_updated`, `unmatched_ids` from the Python output.
+
+### 6.5.6 Record stats for Phase 7
+
+Capture for the Phase 7 report and the skill's return payload:
+
+```yaml
+graph_back_pointers:
+  status: "applied" | "skipped" | "failed"
+  reason: "<reason if skipped or failed, omit if applied>"
+  nodes_updated: N           # 0 when skipped
+  unmatched_ids: ["..."]     # ids in touched entities but not found in graph.json
+```
+
+These values are threaded through to Phase 7's report block under a new **"Graph back-pointers"** section and returned in the skill's result payload to callers (e.g. `/bedrock:learn`).
+
+---
+
 ## Phase 6 — Publish
 
 ### 6.1 Prepare commit
@@ -850,7 +1007,7 @@ Sources: `memory`, `github`, `jira`, `confluence`, `gdoc`, `csv`, `manual`, `ses
 vault: preserves N entities [source: <sources>]
 ```
 
-Or, if called by `/bedrock:teach`:
+Or, if called by `/bedrock:learn`:
 ```
 vault: teaches <source-name>, creates N updates M entities [source: <type>]
 ```
@@ -862,6 +1019,12 @@ vault: teaches <source-name>, creates N updates M entities [source: <type>]
 ```bash
 # Stage touched entities (includes actor subfolders: actors/*/nodes/)
 git -C <VAULT_PATH> add actors/ people/ teams/ topics/ discussions/ projects/ fleeting/
+
+# Stage graphify back-pointer changes when Phase 6.5 ran successfully.
+# Only run when graphify-out/graph.json exists — `git add` of a non-existent path errors out.
+if [ -f "<VAULT_PATH>/graphify-out/graph.json" ]; then
+  git -C <VAULT_PATH> add graphify-out/graph.json
+fi
 
 # Check if there is anything to commit
 git -C <VAULT_PATH> diff --cached --quiet && echo "Nothing to commit" && exit 0
@@ -990,7 +1153,7 @@ Present to the user:
 
 Omit this section entirely when Phase 0.2 was skipped (no `graphify_output_path`, or backward-compat path match).
 
-The same four fields are included in the skill's return payload (e.g., consumed by `/bedrock:teach`):
+The same four fields are included in the skill's return payload (e.g., consumed by `/bedrock:learn`):
 
 ```yaml
 graphify_merge:
@@ -998,6 +1161,26 @@ graphify_merge:
   nodes_merged: M
   edges_added: P
   stale_flag_set: true | false
+```
+
+### Graph back-pointers (Phase 6.5)
+| Metric | Value |
+|---|---|
+| Status | applied / skipped / failed |
+| Reason (skipped/failed) | missing / empty / invalid_json / no_code_entities / <error> |
+| Nodes updated | N (0 when skipped) |
+| Unmatched ids | list (ids present in touched entities but absent from graph.json) |
+
+When `Status = applied`, the back-pointer write is part of the same git commit as the entities (Phase 6 stages `graphify-out/graph.json` alongside the entity directories). When `Status = skipped` or `failed`, no graph mutation occurred and the vault's `graph.json` is untouched.
+
+The same fields are included in the skill's return payload:
+
+```yaml
+graph_back_pointers:
+  status: "applied" | "skipped" | "failed"
+  reason: "..."        # omit when applied
+  nodes_updated: N
+  unmatched_ids: ["..."]
 ```
 
 ### Sources consulted
@@ -1041,3 +1224,11 @@ graphify_merge:
 | 20 | **Graphify merge backward-compat** — if `graphify_output_path` resolves to the same absolute path as `<VAULT_PATH>/graphify-out/`, Phase 0.2 is a no-op. Legacy callers and `/bedrock:sync` continue to work unchanged. |
 | 21 | **Graphify merge is atomic** — `graph.json` is merged into a `.staging` file and atomically renamed. If validation or merge fails, the vault's `graph.json` is untouched. |
 | 22 | **`.graphify_analysis.json` is marked stale, never recomputed** — Phase 0.2 sets `stale: true` on merge. `/bedrock:compress` owns recomputation. |
+| 23 | **`actor_context` scopes the corpus** — when present in Phase 1.1 / 1.3 input, `file_type=document/paper` graphify nodes become `code` of that actor with `node_type ∈ {concept, decision}`; when absent, classification falls back to corpus-agnostic logic (concept global / topic / fleeting). The caller (e.g. `/learn`) decides which mode to invoke. |
+| 24 | **Semantic grouping precedes filtering** — Phase 1.3 step 5 clusters graphify nodes by `semantically_similar_to ≥ code.cluster_threshold` (default 0.85) or community co-membership BEFORE the relevance filter. Each cluster maps to at most one `code` candidate carrying every `graphify_node_ids`. |
+| 25 | **Per-actor cap, no global cap** — `code.max_per_actor` (default 200, from `.bedrock/config.json`) caps `code` candidates per actor. Ranking inside the cap: `is_god_node` > `degree` > `edge_count`. There is NO absolute global cap on the number of `code` entities in the vault. |
+| 26 | **`graphify_node_ids` is always written as an array** — even when the cluster has a single member. At read time, `/preserve` accepts both the array form and the legacy singular `graphify_node_id` (string); it always writes the array on output. There is no batch migration. |
+| 27 | **No English keyword regex for relevance** — the previous label allowlist (`Service|Controller|Client|Factory|Handler|Mapper|Gateway|Provider`) is REMOVED. Relevance comes from confidence + community signals (`is_god_node`, `degree > community average`, `edge_count ≥ 2`). Trivial label exclusion (`Test`, `Mock`, `Builder`, etc.) is preserved. |
+| 28 | **Phase 6.5 is atomic** — `graph.json` is written to a `.staging` file and atomically renamed via `mv`. If the Python block fails, `mv` does NOT run, the vault's `graph.json` stays intact. Same pattern as Phase 0.2 (Rule 21). No write to `graph.json` occurs outside Phase 0.2 and Phase 6.5. |
+| 29 | **Phase 6.5 is best-effort** — when `<VAULT_PATH>/graphify-out/graph.json` is missing, empty, invalid JSON, or no `code` entities were touched, Phase 6.5 silently skips with an explicit `status` and `reason` in the Phase 7 report. `/preserve` does NOT fail. Vaults without `graphify-out/` continue to work without the bridge. |
+| 30 | **Phase 6.5 is idempotent** — `vault_entity_path` is always overwritten with the current path, never appended. Running `/preserve` twice in a row over the same entities does not duplicate fields nor alter any other node attribute. Unmatched ids (graphify re-run, id changed) surface as a warning but never block. |

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -107,10 +107,10 @@ Check for external tools, environment variables, and MCP servers that enhance th
 
 | Dependency | Check method | What it unlocks |
 |---|---|---|
-| graphify | Glob: `~/.claude/skills/graphify/SKILL.md` | **Required.** Extraction engine for all `/bedrock:teach` ingestion. Without it, /teach cannot function. |
-| docling | Bash: `command -v docling >/dev/null 2>&1` | **Required.** Universal file → markdown converter used by `/bedrock:teach` to ingest DOCX, PPTX, XLSX, HTML, EPUB, PDF, images, and other non-markdown formats. Without it, /teach can only ingest text-native formats. |
-| CONFLUENCE_API_TOKEN + CONFLUENCE_USER_EMAIL | Bash: `test -n "$CONFLUENCE_API_TOKEN" && test -n "$CONFLUENCE_USER_EMAIL"` | Confluence page ingestion via `/bedrock:teach` (API strategy). |
-| GOOGLE_ACCESS_TOKEN | Bash: `test -n "$GOOGLE_ACCESS_TOKEN"` | Google Docs and Sheets ingestion via `/bedrock:teach` (API strategy). |
+| graphify | Glob: `~/.claude/skills/graphify/SKILL.md` | **Required.** Extraction engine for all `/bedrock:learn` ingestion. Without it, /learn cannot function. |
+| docling | Bash: `command -v docling >/dev/null 2>&1` | **Required.** Universal file → markdown converter used by `/bedrock:learn` to ingest DOCX, PPTX, XLSX, HTML, EPUB, PDF, images, and other non-markdown formats. Without it, /learn can only ingest text-native formats. |
+| CONFLUENCE_API_TOKEN + CONFLUENCE_USER_EMAIL | Bash: `test -n "$CONFLUENCE_API_TOKEN" && test -n "$CONFLUENCE_USER_EMAIL"` | Confluence page ingestion via `/bedrock:learn` (API strategy). |
+| GOOGLE_ACCESS_TOKEN | Bash: `test -n "$GOOGLE_ACCESS_TOKEN"` | Google Docs and Sheets ingestion via `/bedrock:learn` (API strategy). |
 | claude-in-chrome MCP | ToolSearch: `select:mcp__claude-in-chrome__tabs_context_mcp` (succeeds = available) | **Optional.** Browser fallback for Confluence pages when API credentials are unavailable. |
 
 ### 1.2.1 Auto-install graphify if missing
@@ -199,8 +199,8 @@ If both steps failed (no `pipx`/`pip`, no network, or a permissions error), prin
 
 | Dependency | Status | What it unlocks |
 |---|---|---|
-| graphify | installed / NOT FOUND | Extraction engine for /teach |
-| docling | installed / NOT FOUND | Universal file → markdown converter for /teach |
+| graphify | installed / NOT FOUND | Extraction engine for /learn |
+| docling | installed / NOT FOUND | Universal file → markdown converter for /learn |
 | Confluence API credentials | configured / NOT SET | Confluence page ingestion (API) |
 | Google API token | configured / NOT SET | Google Docs/Sheets ingestion (API) |
 | claude-in-chrome MCP | available / NOT FOUND | Browser fallback for Confluence |
@@ -220,22 +220,22 @@ If both steps failed (no `pipx`/`pip`, no network, or a permissions error), prin
 For **graphify** specifically (required):
 
 ```
-> graphify is not installed. This is REQUIRED for /bedrock:teach to work.
+> graphify is not installed. This is REQUIRED for /bedrock:learn to work.
 > To install, check https://github.com/safishamsi/graphify for instructions.
 >
-> Your vault will initialize, but /bedrock:teach will not function until graphify is installed.
+> Your vault will initialize, but /bedrock:learn will not function until graphify is installed.
 ```
 
 For **docling** specifically (required for non-markdown ingestion):
 
 ```
-> docling is not installed. This is REQUIRED for /bedrock:teach to ingest non-markdown files
+> docling is not installed. This is REQUIRED for /bedrock:learn to ingest non-markdown files
 > (DOCX, PPTX, XLSX, PDF, HTML, EPUB, images, etc.).
 > To install manually: pipx install docling  (or: pip install --user docling)
 > More info: https://github.com/docling-project/docling
 >
-> Your vault will initialize, but /bedrock:teach will only handle markdown/text inputs until
-> docling is installed. /teach also attempts a silent auto-install on first invocation if the
+> Your vault will initialize, but /bedrock:learn will only handle markdown/text inputs until
+> docling is installed. /learn also attempts a silent auto-install on first invocation if the
 > dependency is still missing.
 ```
 
@@ -651,7 +651,7 @@ New domains can be added as the vault grows.
 | Action | Skill |
 |---|---|
 | Search and query the vault | `/bedrock:ask` |
-| Ingest external sources (Confluence, Google Docs, GitHub repositories, remote URLs, and any docling-supported file format — DOCX, PPTX, XLSX, PDF, HTML, EPUB, images, and more) | `/bedrock:teach` |
+| Ingest external sources (Confluence, Google Docs, GitHub repositories, remote URLs, and any docling-supported file format — DOCX, PPTX, XLSX, PDF, HTML, EPUB, images, and more) | `/bedrock:learn` |
 | Create or update entities manually | `/bedrock:preserve` |
 | Deduplicate and check vault health | `/bedrock:compress` |
 | Re-sync entities with external sources | `/bedrock:sync` |
@@ -1439,7 +1439,7 @@ After all files are created, present the user with a summary and next steps.
 1. **Open the vault in Obsidian** — Open this folder as an Obsidian vault. You'll see the example entities
    and their connections in the graph view immediately.
 
-2. **Ingest your first source** — Run `/bedrock:teach <url>` to import content from:
+2. **Ingest your first source** — Run `/bedrock:learn <url>` to import content from:
    - A GitHub repository URL
    - A Confluence page URL
    - A Google Docs URL

--- a/skills/sync/SKILL.md
+++ b/skills/sync/SKILL.md
@@ -115,7 +115,7 @@ in the vault (incremental diff), and delegates all changes to `/bedrock:preserve
 `/bedrock:sync` **does NOT write entities directly** — all entity writing goes through `/bedrock:preserve`.
 After re-sync, `/bedrock:preserve` updates `synced_at` in the `sources` field of affected entities.
 
-`/bedrock:sync` **does NOT ingest new sources** — for that, use `/bedrock:teach`.
+`/bedrock:sync` **does NOT ingest new sources** — for that, use `/bedrock:learn`.
 
 **You are an execution agent.** Follow the phases below in order, without skipping steps.
 

--- a/templates/actors/_template_node.md
+++ b/templates/actors/_template_node.md
@@ -1,0 +1,65 @@
+---
+type: code
+name: ""
+aliases: []  # ["Display Name", "camelCaseName"] — min 1 alias
+actor: "[[actor-name]]"  # parent actor (wikilink to existing actor)
+node_type: ""  # function | class | module | concept | decision | interface | endpoint
+source_file: ""  # relative path inside the actor's repo (e.g. "src/Controllers/PaymentController.cs")
+source_location: ""  # optional — line range like "L42-L85"
+description: ""
+graphify_node_ids: []  # ["billing_api_processTransaction", "billing_api_processTransactionV2"] — one or more graphify node ids grouped by semantic similarity
+confidence: ""  # EXTRACTED | INFERRED | AMBIGUOUS — strongest edge confidence
+relations: []  # ["[[other-code-slug]]", "[[other-actor-code-slug]]"] — optional wikilinks to related code entities
+sources: []  # [{url: "https://...", type: "github-repo|graphify|manual", synced_at: YYYY-MM-DD}]
+updated_at: YYYY-MM-DD
+updated_by: ""
+tags: [type/code]  # + domain/{...} inherited from the parent actor
+---
+
+<!-- Zettelkasten role: permanent note extension (sub-entity of actor) -->
+<!-- Links in the body should have textual context when possible: "calls [[ProcessPayment]] to execute the transaction". For nodes with many relations, frontmatter `relations` is acceptable without textual context. -->
+
+# Code Node Name
+
+> Brief description of this node's function or role within the parent actor.
+
+## Details
+
+| Field | Value |
+|---|---|
+| Actor | [[actor-name]] |
+| Node type | function / class / module / concept / decision / interface / endpoint |
+| Source file | `relative/path/in/repo` |
+| Source location | `L42-L85` (optional) |
+| Confidence | EXTRACTED / INFERRED / AMBIGUOUS |
+| Graphify node ids | `node_id_1`, `node_id_2` |
+
+## What it does
+
+<!-- One paragraph describing the node's responsibility. Use plain language. -->
+
+## Relations
+
+<!-- Wikilinks to related code entities, with textual context. Example: -->
+<!-- - calls [[process-payment]] to delegate the actual charge -->
+<!-- - implements the [[event-publisher-pattern]] decision documented in the parent actor -->
+
+---
+
+## Expected Bidirectional Links
+
+> This section is a reference for agents and can be removed in real pages.
+
+| From | To | Field |
+|---|---|---|
+| Code → Actor | `[[actor-name]]` | `actor` in frontmatter |
+| Actor → Code | `[[code-slug]]` | "Knowledge Nodes" section in the parent actor |
+| Code → Code | `[[other-code-slug]]` | `relations` in frontmatter or wikilink in body |
+| Topic → Code | `[[code-slug]]` | "Related Code" section in topic (when applicable) |
+
+## Graph Bridge
+
+> The graphify nodes referenced by `graphify_node_ids` carry an optional reverse pointer
+> `vault_entity_path` written by `/bedrock:preserve` Phase 6.5 (TODO — Part 3 of the
+> code-graphify-bridge spec). When present, the path is relative to the vault root
+> (e.g. `actors/billing-api/nodes/process-transaction.md`).


### PR DESCRIPTION
Sync combinado com upstream iurykrieger/claude-bedrock. Originalmente planejado como 2 PRs (PR-B features, PR-C rename), mas consolidado porque o rename teach→learn arrasta conteúdo de várias skills upstream — separar duplica conflitos.

## Conteúdo

### Rename teach → learn (commit 04cd6bb upstream)
- skills/teach/SKILL.md → skills/learn/SKILL.md (rename git preserved)
- Atualização de referências em CLAUDE.md, README.md, site/, index.html, entities, e cross-skill refs (ask, sync, healthcheck, gdoc, confluence, preserve)

### Features substantivas do upstream
- skills/ask: graph.json como structured index
- skills/preserve: Phase 6.5 (graph back-pointers); Rules 23-30 (actor_context, semantic grouping, per-actor cap)
- skills/learn: Phase 3.1.1 (actor_context derivation)
- skills/healthcheck, sync, gdoc-to-markdown, confluence-to-markdown: updates

### Novos artefatos
- hooks/error_reporter.py + hooks.json + 14 test files (UserPrompt hook pra detecção/redaction de erros)
- templates/actors/_template_node.md
- entities/code.md, fleeting.md, sources-field.md atualizados

## Customizações do fork preservadas

Re-aplicadas via 'git apply' após resolver conflitos com upstream:
- skills/preserve sections 4.2.1 e 4.2.2 (management routing rules) — commit 4f52291
- skills/setup product-management preset — commit 24e9829
- skills/learn rich Confluence extraction via /wiki/exportword — commit 73dd232 (originalmente em teach, reaplicado em learn)

## NÃO incluído (intencional)
- .vibeflow/* artifacts internos do upstream (audits, PRDs, specs, prompt-packs do iurykrieger)

## Diff stats
32 arquivos, +1645/-184 linhas

## Follow-ups
- Atualizar mgmt/CLAUDE.md (vault local) pra /bedrock:learn
- Atualizar memory files que mencionam teach
- Atualizar concept actor prod-data-kb se necessário

🤖 Co-authored via sync seletivo upstream